### PR TITLE
Improve pluggability

### DIFF
--- a/gist_memory/agent.py
+++ b/gist_memory/agent.py
@@ -93,6 +93,7 @@ class Agent:
             dedup_cache=dedup_cache,
             summary_creator=summary_creator,
             update_summaries=update_summaries,
+            embed_fn=embed_text,
         )
         self.metrics = self.prototype_system.metrics
         self.prompt_budget = prompt_budget
@@ -108,6 +109,11 @@ class Agent:
         if not isinstance(value, Chunker):
             raise TypeError("chunker must implement Chunker interface")
         self.prototype_system.chunker = value
+        try:
+            name = getattr(value, "id", value.__class__.__name__.lower())
+            self.store.meta["chunker"] = name
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     @property
@@ -117,6 +123,7 @@ class Agent:
     @similarity_threshold.setter
     def similarity_threshold(self, value: float) -> None:
         self.prototype_system.similarity_threshold = value
+        self.store.meta["tau"] = float(value)
 
     # ------------------------------------------------------------------
     @property

--- a/gist_memory/prototype/conflict_flagging.py
+++ b/gist_memory/prototype/conflict_flagging.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import numpy as np
 
-from .models import RawMemory
+from ..models import RawMemory
 
 
 _NEG_WORDS = {"not", "no", "never", "n't"}


### PR DESCRIPTION
## Summary
- fix relative import for conflict flagging utilities
- persist chunker and tau when changed on the Agent
- allow PrototypeSystemStrategy to accept custom embedding functions

## Testing
- `pytest tests/test_agent.py::test_reconfigure_chunker tests/test_agent.py::test_reconfigure_similarity_threshold -q`
- `pytest tests/test_agent_canonical.py::test_add_memory_uses_canonical -q`
- `pytest -q --maxfail=1` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683c7e1379588329b768c6e833128c95