### PR TITLE
Improve pluggability

### DIFF
--- a/gist_memory/prototype/conflict_flagging.py
+++ b/gist_memory/prototype/conflict_flagging.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import numpy as np
 
-from .models import RawMemory
+from ..models import RawMemory
 
 
 _NEG_WORDS = {"not", "no", "never", "n't"}


### PR DESCRIPTION
## Summary
- fix relative import for conflict flagging utilities
- persist chunker and tau when changed on the Agent
- allow PrototypeSystemStrategy to accept custom embedding functions
- expose embedding function customization through Agent

## Testing
- `flake8 gist_memory/agent.py gist_memory/prototype/conflict_flagging.py gist_memory/prototype_system_strategy.py` *(fails: E303, E501)*
- `pytest tests/test_agent.py::test_reconfigure_chunker tests/test_agent.py::test_reconfigure_similarity_threshold -q`
- `pytest tests/test_agent_canonical.py::test_add_memory_uses_canonical -q`
- `pytest -q --maxfail=1` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_683c7e1379588329b768c6e833128c95