### PR TITLE
Add optional LLM helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ print(f"Strategy used: {trace.strategy_name}")
 # Now you can use compressed_memory.text in your LLM pipeline
 # llm_input = f"Context: {compressed_memory.text}\n\nQuestion: What is this about?"
 # response = your_llm_function(llm_input)
+
+For quick testing with a small local model or OpenAI, you can also use
+`examples.llm_helpers.run_llm()` which wraps minimal API calls.
 ```
 
 This allows for seamless integration of context compression into your Python-based LLM applications, making them more efficient and capable of handling larger amounts of information within token limits.

--- a/docs/DEVELOPING_COMPRESSION_STRATEGIES.md
+++ b/docs/DEVELOPING_COMPRESSION_STRATEGIES.md
@@ -181,13 +181,10 @@ Compact Memory provides utilities that can be helpful:
     *   `compact_memory.token_utils.token_count(tokenizer, text)`: Counts tokens in a text using the provided tokenizer.
 *   **Chunking:**
     *   While strategies can implement their own chunking, Compact Memory also has chunking utilities (e.g., `SentenceWindowChunker`) that can be used externally to prepare input for your strategy or internally if your strategy requires chunk-based processing. See `compact_memory.chunker`.
-*   **LLM Providers (Advanced):**
-    *   If your strategy involves calling an LLM (e.g., for abstractive summarization), you can leverage Compact Memory's LLM provider abstractions (`compact_memory.llm_providers_abc.LLMProvider`, with implementations like `OpenAIProvider`, `GeminiProvider`, `LocalTransformersProvider`).
-    *   This typically involves:
-        1.  Accepting LLM configuration (model name, API keys if needed) in your strategy's `__init__`.
-        2.  Instantiating the chosen provider.
-        3.  Using its `generate_response()` method.
-    *   Ensure your strategy handles API errors gracefully and documents LLM dependencies.
+*   **LLM Helpers (Optional):**
+    *   If your strategy needs to call an LLM, Compact Memory keeps this outside the core package. Check `examples/llm_helpers.py` for lightweight `run_llm()` wrappers that work with small local models or OpenAI.
+    *   You can use these helpers directly or swap in your preferred framework (LangChain, AutoGen, etc.). The helpers simply take a prompt and return the generated text.
+    *   Remember to manage API keys and errors in your own code when using external providers.
 
 ## Structuring Strategy Logic
 

--- a/examples/llm_helpers.py
+++ b/examples/llm_helpers.py
@@ -1,0 +1,128 @@
+"""Minimal helpers for testing Compact Memory output with an LLM."""
+
+from __future__ import annotations
+
+from typing import Optional
+import os
+
+try:  # optional dependency
+    import openai
+except Exception:  # pragma: no cover - optional
+    openai = None  # type: ignore
+
+try:  # optional dependency
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+except Exception:  # pragma: no cover - optional
+    AutoModelForCausalLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
+    torch = None  # type: ignore
+
+
+def run_openai(
+    prompt: str,
+    model_name: str = "gpt-3.5-turbo",
+    *,
+    max_new_tokens: int = 150,
+    api_key: Optional[str] = None,
+) -> str:
+    """Return completion from OpenAI chat models.
+
+    Args:
+        prompt: The full text prompt to send.
+        model_name: Target model identifier.
+        max_new_tokens: Maximum tokens to generate.
+        api_key: Optional API key. Falls back to the ``OPENAI_API_KEY``
+            environment variable.
+
+    Returns:
+        The generated completion text.
+    """
+    if openai is None:
+        raise ImportError("openai package is required for run_openai()")
+    if api_key is None:
+        api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        openai.api_key = api_key
+    messages = [{"role": "user", "content": prompt}]
+    resp = openai.ChatCompletion.create(
+        model=model_name,
+        messages=messages,
+        max_tokens=max_new_tokens,
+    )
+    return resp.choices[0].message["content"].strip()
+
+
+def run_local(
+    prompt: str, model_name: str = "distilgpt2", *, max_new_tokens: int = 128
+) -> str:
+    """Return completion from a local transformers model.
+
+    Args:
+        prompt: Prompt to send to the model.
+        model_name: Hugging Face model identifier.
+        max_new_tokens: Maximum tokens to generate.
+
+    Returns:
+        The generated completion text.
+    """
+    if AutoModelForCausalLM is None or AutoTokenizer is None or torch is None:
+        raise ImportError(
+            "transformers with PyTorch is required for run_local()"
+        )  # noqa: E501
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name,
+        local_files_only=True,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        local_files_only=True,
+    )
+    inputs = tokenizer(prompt, return_tensors="pt", truncation=True)
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            pad_token_id=getattr(tokenizer, "eos_token_id", None),
+        )
+    text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    if text.startswith(prompt):
+        text = text[len(prompt) :]  # noqa: E203
+    return text.strip()
+
+
+def run_llm(
+    prompt: str,
+    *,
+    provider: str = "local",
+    model_name: str = "distilgpt2",
+    max_new_tokens: int = 128,
+    api_key: Optional[str] = None,
+) -> str:
+    """Dispatch to ``run_openai`` or ``run_local`` based on ``provider``.
+
+    Args:
+        prompt: Full prompt text.
+        provider: ``"openai"`` or ``"local"``.
+        model_name: Model identifier understood by the provider.
+        max_new_tokens: Maximum tokens to generate.
+        api_key: API key for cloud providers.
+
+    Returns:
+        The generated completion text.
+    """
+    if provider == "openai":
+        return run_openai(
+            prompt,
+            model_name=model_name,
+            max_new_tokens=max_new_tokens,
+            api_key=api_key,
+        )
+    return run_local(
+        prompt,
+        model_name=model_name,
+        max_new_tokens=max_new_tokens,
+    )
+
+
+__all__ = ["run_openai", "run_local", "run_llm"]


### PR DESCRIPTION
## Summary
- add `examples/llm_helpers` with simple OpenAI/local wrappers
- document helper usage in README and strategy guide
- remove stray install log and demo notebook

## Testing
- `pre-commit run --files README.md docs/DEVELOPING_COMPRESSION_STRATEGIES.md examples/llm_helpers.py`
- `pytest -q` *(fails: ImportError from transformers and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6840426a8ac0832987fa805490175d57