### PR TITLE
Add contrib strategy package

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501,F401,E731,F541

--- a/README.md
+++ b/README.md
@@ -273,6 +273,30 @@ Plugins can add more strategies. For example, the `rationale_episode` strategy l
 You can then set it via `compact-memory config set default_strategy_id rationale_episode`.
 Note: The old method of enabling strategies via `compact_memory_config.yaml` directly is being phased out in favor of the `config set` command and plugin system.
 
+### Using Contrib Strategies
+
+Experimental strategies bundled in the repository live under the `contrib` package. They are not registered by default.
+
+```python
+from contrib import enable_all_contrib_strategies
+from compact_memory.compression import get_compression_strategy, register_compression_strategy
+
+# Enable all contrib strategies
+enable_all_contrib_strategies()
+
+# Or register individually
+from contrib.strategies.chained import ChainedStrategy
+register_compression_strategy("chained", ChainedStrategy)
+```
+
+Once registered, these strategies behave like any other:
+
+```bash
+compact-memory compress text.txt --strategy chained --budget 200
+```
+
+Contrib strategies are experimental and may change without notice.
+
 ## Why Compact Memory?
 
 Compact Memory offers unique advantages for advancing LLM memory capabilities:

--- a/contrib/__init__.py
+++ b/contrib/__init__.py
@@ -1,0 +1,19 @@
+"""Optional community-contributed strategies."""
+
+from __future__ import annotations
+
+from compact_memory.compression import register_compression_strategy
+
+
+def enable_all_contrib_strategies() -> None:
+    """Register all strategies contained in :mod:`contrib`."""
+    from .strategies.chained import ChainedStrategy
+    from .strategies.rationale_episode import RationaleEpisodeStrategy
+
+    register_compression_strategy(ChainedStrategy.id, ChainedStrategy, source="contrib")
+    register_compression_strategy(
+        RationaleEpisodeStrategy.id, RationaleEpisodeStrategy, source="contrib"
+    )
+
+
+__all__ = ["enable_all_contrib_strategies"]

--- a/contrib/strategies/__init__.py
+++ b/contrib/strategies/__init__.py
@@ -1,0 +1,3 @@
+"""Experimental compression strategies."""
+
+__all__ = ["chained", "rationale_episode"]

--- a/contrib/strategies/chained.py
+++ b/contrib/strategies/chained.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Experimental strategy chaining built-in steps."""
+
+from typing import List, Union, Any
+
+from compact_memory.compression import NoCompression, ImportanceCompression
+from compact_memory.compression.pipeline_strategy import PipelineCompressionStrategy
+from compact_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+
+
+class ChainedStrategy(CompressionStrategy):
+    """Simple pipeline of importance filtering followed by truncation."""
+
+    id = "chained"
+
+    def __init__(self) -> None:
+        self.pipeline = PipelineCompressionStrategy(
+            [ImportanceCompression(), NoCompression()]
+        )
+
+    def compress(
+        self,
+        text_or_chunks: Union[str, List[str]],
+        llm_token_budget: int,
+        **kwargs: Any,
+    ) -> tuple[CompressedMemory, CompressionTrace]:
+        return self.pipeline.compress(text_or_chunks, llm_token_budget, **kwargs)
+
+    def save_learnable_components(
+        self, path: str
+    ) -> None:  # pragma: no cover - no learnables
+        pass

--- a/contrib/strategies/rationale_episode.py
+++ b/contrib/strategies/rationale_episode.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Experimental strategy demonstrating rationale episodes."""
+
+from typing import List, Union, Any
+
+from compact_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+
+
+class RationaleEpisodeStrategy(CompressionStrategy):
+    """Append a rationale note to each chunk of text."""
+
+    id = "rationale_episode"
+
+    def compress(
+        self,
+        text_or_chunks: Union[str, List[str]],
+        llm_token_budget: int,
+        **kwargs: Any,
+    ) -> tuple[CompressedMemory, CompressionTrace]:
+        if isinstance(text_or_chunks, list):
+            text = " ".join(text_or_chunks)
+        else:
+            text = text_or_chunks
+        result = f"Rationale: {text}"
+        truncated = result[:llm_token_budget] if llm_token_budget else result
+        compressed = CompressedMemory(text=truncated)
+        trace = CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={"llm_token_budget": llm_token_budget},
+            input_summary={"input_length": len(text)},
+            output_summary={"output_length": len(truncated)},
+            final_compressed_object_preview=truncated[:50],
+        )
+        return compressed, trace
+
+    def save_learnable_components(
+        self, path: str
+    ) -> None:  # pragma: no cover - no learnables
+        pass

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,0 +1,24 @@
+from typer.testing import CliRunner
+
+from contrib import enable_all_contrib_strategies
+from compact_memory.cli import app
+from compact_memory.compression import (
+    get_compression_strategy,
+    available_strategies,
+)
+
+
+def test_enable_all_registers_contrib():
+    enable_all_contrib_strategies()
+    assert "chained" in available_strategies()
+    cls = get_compression_strategy("chained")
+    assert cls.__name__ == "ChainedStrategy"
+
+
+def test_cli_list_strategies_include_contrib():
+    runner = CliRunner()
+    res = runner.invoke(app, ["dev", "list-strategies"])
+    assert "chained" not in res.stdout
+    res = runner.invoke(app, ["dev", "list-strategies", "--include-contrib"])
+    assert res.exit_code == 0
+    assert "chained" in res.stdout


### PR DESCRIPTION
## Summary
- create a `contrib` package for experimental strategies
- provide `ChainedStrategy` and `RationaleEpisodeStrategy`
- add helper to enable all contrib strategies
- update CLI with `--include-contrib` option and warning for contrib use
- document contrib usage in README
- configure flake8 for the repo
- test contrib registration and CLI listing

## Testing
- `pre-commit run --files README.md compact_memory/cli.py contrib/__init__.py contrib/strategies/chained.py contrib/strategies/rationale_episode.py contrib/strategies/__init__.py tests/test_contrib.py .flake8`
- `pytest -q` *(fails: ImportError: AutoModelForCausalLM requires the PyTorch library)*

------
https://chatgpt.com/codex/tasks/task_e_68404c6ba94c83298b034e267b37a3cc