### PR TITLE
Clarify Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Setup script executed during Codex container setup.
+# Setup script executed automatically during Codex container setup.
+# Not intended for general use; local installations should run setup.sh.
 # Install dependencies used during testing and examples.
 
 set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ This project requires **Python 3.11+**.
    ```bash
    FULL_INSTALL=1 bash setup.sh
    ```
+Note: The repository also includes `.codex/setup.sh`, which is intended solely for the Codex environment and is not needed for general users.
 
 2.  **Install `compact-memory`:**
     This makes the `compact-memory` CLI tool available. You have two main options:


### PR DESCRIPTION
## Summary
- document that `.codex/setup.sh` is only for Codex environments
- clarify comments in `.codex/setup.sh`

## Testing
- `pre-commit run --files README.md .codex/setup.sh`
- `pytest` *(fails: ImportError, NameError and AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6840523e5c748329a6f6fea66d8888ed