### PR TITLE
Fix setup script for editable install

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -19,6 +19,8 @@ if [ -f requirements.txt ]; then
         openai tiktoken numpy faiss-cpu click>=8.2 tqdm pydantic \
         pyyaml transformers "typer[all]>=0.16.0" portalocker \
         "rich>=13.6"
+    # Ensure the build backend is available for editable installs
+    pip3 install --prefer-binary setuptools wheel
     # Install the project itself without pulling in extra dependencies.
     pip3 install -e . --no-build-isolation --no-deps
 fi


### PR DESCRIPTION
## Summary
- ensure `.codex/setup.sh` installs setuptools and wheel before editable installation

## Testing
- `pre-commit run --files .codex/setup.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_6840735595a08329bec2d5c3e4be2f7e