### PR TITLE
Switch compress to explicit flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Breaking Changes
+- CLI `compress` command now requires explicit input flags: `--text`, `--file`, or `--dir`. Positional auto-detection has been removed.
+

--- a/README.md
+++ b/README.md
@@ -43,19 +43,25 @@ For more detailed installation options, see the [Installation](#installation) se
 The `compact-memory` CLI provides a straightforward way to apply compression strategies. For example, to compress a text file using the `first_last` strategy with a token budget of 100:
 
 ```bash
-compact-memory compress "path/to/your_document.txt" --strategy first_last --budget 100
+compact-memory compress --file "path/to/your_document.txt" --strategy first_last --budget 100
 ```
 
 Or, to compress a string directly:
 
 ```bash
-compact-memory compress "This is a very long string that needs to be much shorter to fit into my LLM's context window." --strategy truncate --budget 20
+compact-memory compress --text "This is a very long string that needs to be much shorter to fit into my LLM's context window." --strategy truncate --budget 20
+```
+
+You can also pipe input via standard input:
+
+```bash
+cat notes.txt | compact-memory compress --text - --strategy truncate --budget 20
 ```
 
 The output will be the compressed text printed to the console. You can save it to a file using the `-o` option:
 
 ```bash
-compact-memory compress "path/to/your_document.txt" -s first_last -b 100 -o "path/to/compressed_output.txt"
+compact-memory compress --file "path/to/your_document.txt" -s first_last -b 100 -o "path/to/compressed_output.txt"
 ```
 
 ### Using Compressed Output in an LLM Prompt
@@ -188,7 +194,7 @@ Shared strategies can be distributed as standard Python packages (e.g., via PyPI
 
 *   **Using a Shared Strategy:** Once installed and discovered, you can use a shared strategy like any built-in strategy by specifying its `strategy_id` in the CLI or Python API:
     ```bash
-    compact-memory compress "my text" --strategy community_strategy_id --budget 100
+    compact-memory compress --text "my text" --strategy community_strategy_id --budget 100
     ```
     ```python
     from compact_memory.compression import get_compression_strategy
@@ -262,7 +268,7 @@ To use a specific strategy, you can set it as a global default or specify it per
 compact-memory config set default_strategy_id prototype
 
 # Use a specific strategy for a compress command
-compact-memory compress "My text..." --strategy first_last --budget 100
+compact-memory compress --text "My text..." --strategy first_last --budget 100
 ```
 
 Plugins can add more strategies. For example, the `rationale_episode` strategy lives in the optional
@@ -290,7 +296,7 @@ register_compression_strategy("chained", ChainedStrategy)
 Once registered, these strategies behave like any other:
 
 ```bash
-compact-memory compress text.txt --strategy chained --budget 200
+compact-memory compress --file text.txt --strategy chained --budget 200
 ```
 
 Contrib strategies are experimental and may change without notice.
@@ -436,8 +442,8 @@ compact-memory query "Summarize recent findings on AI ethics" --model-id openai/
 **5. Compress Text (Standalone Utility):**
 Compress text using a specific strategy without necessarily interacting with an agent's stored memory. This is useful for quick text compression tasks.
 ```bash
-compact-memory compress "This is a very long piece of text that needs to be shorter." --strategy first_last --budget 50
-compact-memory compress path/to/another_document.txt -s prototype -b 200 -o compressed_summary.txt
+compact-memory compress --text "This is a very long piece of text that needs to be shorter." --strategy first_last --budget 50
+compact-memory compress --file path/to/another_document.txt -s prototype -b 200 -o compressed_summary.txt
 ```
 
 **Developer Tools & Evaluation:**

--- a/completions/compact-memory.bash
+++ b/completions/compact-memory.bash
@@ -1,0 +1,10 @@
+_python_mcompact_memorycli_completion() {
+    local IFS=$'
+'
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _PYTHON _M COMPACT_MEMORY.CLI_COMPLETE=complete_bash $1 ) )
+    return 0
+}
+
+complete -o default -F _python_mcompact_memorycli_completion python -m compact_memory.cli

--- a/completions/compact-memory.fish
+++ b/completions/compact-memory.fish
@@ -1,0 +1,10 @@
+_python_mcompact_memorycli_completion() {
+    local IFS=$'
+'
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _PYTHON _M COMPACT_MEMORY.CLI_COMPLETE=complete_bash $1 ) )
+    return 0
+}
+
+complete -o default -F _python_mcompact_memorycli_completion python -m compact_memory.cli

--- a/completions/compact-memory.zsh
+++ b/completions/compact-memory.zsh
@@ -1,0 +1,10 @@
+_python_mcompact_memorycli_completion() {
+    local IFS=$'
+'
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _PYTHON _M COMPACT_MEMORY.CLI_COMPLETE=complete_bash $1 ) )
+    return 0
+}
+
+complete -o default -F _python_mcompact_memorycli_completion python -m compact_memory.cli

--- a/docs/SHARING_STRATEGIES.md
+++ b/docs/SHARING_STRATEGIES.md
@@ -146,7 +146,7 @@ This will check for required files, fields in the manifest, and basic loadabilit
     Once a strategy is installed and discoverable, you can use it just like a built-in one by referencing its `strategy_id`:
     *   **CLI:**
         ```bash
-        compact-memory compress input.txt --strategy <shared_strategy_id> --budget <value>
+        compact-memory compress --file input.txt --strategy <shared_strategy_id> --budget <value>
         ```
     *   **Python API:**
         ```python

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -62,18 +62,21 @@ Queries an agent (specified by `--memory-path` or configuration) with the provid
 
 Compresses text content from a string, file, or directory using a specified strategy and token budget. This is a standalone utility.
 
-**Usage:** `compact-memory compress [OPTIONS] INPUT_SOURCE`
+**Usage:** `compact-memory compress [OPTIONS] (--text TEXT | --file PATH | --dir PATH)`
 
-**Arguments:**
-*   `INPUT_SOURCE`: Input text directly, or a path to a text file or directory of text files to compress. (Required)
+**Input Options (choose exactly one):**
+*   `--text TEXT`: Raw text to compress. Use `-` to read from stdin.
+*   `--file PATH`: Path to a single text file.
+*   `--dir PATH`: Path to a directory of files.
 
 **Options:**
 *   `--strategy / -s TEXT`: Compression strategy ID to use. Overrides the global default strategy. (Required if no global default is set)
 *   `--budget INTEGER`: Token budget for the compressed output. The strategy will aim to keep the output within this limit. (Required)
-*   `--output / -o PATH`: File path to write compressed output. For directory input, this is the root output directory. If unspecified, prints to console.
-*   `--output-trace PATH`: File path to write the CompressionTrace JSON object. (Not applicable for directory input).
-*   `--recursive / -r`: Process text files in subdirectories recursively when `INPUT_SOURCE` is a directory.
-*   `--pattern / -p TEXT`: File glob pattern to match files when `INPUT_SOURCE` is a directory (default: "*.txt"; e.g., `'*.md'`, `'**/*.txt'`).
+*   `--output / -o PATH`: File path to write compressed output when using `--text` or `--file`. Prints to console if unspecified.
+*   `--output-dir PATH`: Directory to write compressed files when using `--dir`.
+*   `--output-trace PATH`: File path to write the `CompressionTrace` JSON object. (Not valid with `--dir`).
+*   `--recursive / -r`: Process text files in subdirectories recursively (valid with `--dir` only).
+*   `--pattern / -p TEXT`: File glob pattern for directory input (valid with `--dir` only; default: "*.txt").
 *   `--verbose-stats`: Show detailed token counts and processing time per item.
 
 

--- a/docs/tutorials/02_building_a_simple_strategy.md
+++ b/docs/tutorials/02_building_a_simple_strategy.md
@@ -141,7 +141,7 @@ Once your strategy is defined and you can import it (and optionally register it 
 *   CLI:
 To use via CLI, you'd typically package this strategy (see \`SHARING_STRATEGIES.md\`). If \`my_strategies.py\` was in a discoverable plugin directory, you could run:
 ```bash
-compact-memory compress "Your long text here..." --strategy first_n_sentences --budget 50 --strategy-params '{"num_sentences": 2}'
+compact-memory compress --text "Your long text here..." --strategy first_n_sentences --budget 50 --strategy-params '{"num_sentences": 2}'
 ```
 *   Python API:
 ```python

--- a/docs/tutorials/03_packaging_a_strategy.md
+++ b/docs/tutorials/03_packaging_a_strategy.md
@@ -106,7 +106,7 @@ Your strategy package directory (\`MyAwesomeStrategyPackage\`) is now ready! Her
 Once a user has your package (either by placing the directory in their plugins folder or by \`pip install\`-ing your Python package if you created one), they can use it like any other strategy:
 ```bash
 compact-memory dev list-strategies # Your strategy should appear here
-compact-memory compress input.txt --strategy awesome_strat --budget 100 --strategy-params '{"custom_param": 10}'
+compact-memory compress --file input.txt --strategy awesome_strat --budget 100 --strategy-params '{"custom_param": 10}'
 ```
 ```python
 from compact_memory.compression import get_compression_strategy

--- a/tests/test_cli_compress.py
+++ b/tests/test_cli_compress.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from typer.testing import CliRunner
+from compact_memory.cli import app
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {"COMPACT_MEMORY_COMPACT_MEMORY_PATH": str(tmp_path)}
+
+
+runner = CliRunner()
+
+
+def test_compress_text_option(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "hello world",
+            "--strategy",
+            "none",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert "hello" in result.stdout
+
+
+def test_compress_stdin(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "-",
+            "--strategy",
+            "none",
+            "--budget",
+            "10",
+        ],
+        input="stdin text",
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert "stdin" in result.stdout
+
+
+def test_compress_file(tmp_path: Path):
+    file_path = tmp_path / "inp.txt"
+    file_path.write_text("file text")
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--file",
+            str(file_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "10",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert "file" in result.stdout
+
+
+def test_compress_directory_recursive(tmp_path: Path):
+    dir_path = tmp_path / "data"
+    dir_path.mkdir()
+    (dir_path / "a.txt").write_text("aaa")
+    sub = dir_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("bbb")
+    out_dir = tmp_path / "out"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--dir",
+            str(dir_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "5",
+            "--recursive",
+            "--output-dir",
+            str(out_dir),
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert (out_dir / "a.txt").exists()
+    assert (out_dir / "sub" / "b.txt").exists()
+
+
+def test_compress_invalid_combo(tmp_path: Path):
+    file_path = tmp_path / "foo.txt"
+    file_path.write_text("foo")
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--file",
+            str(file_path),
+            "--text",
+            "oops",
+            "--strategy",
+            "none",
+            "--budget",
+            "5",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code != 0
+    assert "specify exactly ONE" in result.stderr


### PR DESCRIPTION
## Summary
- revise `compress` command to use `--text`, `--file`, or `--dir`
- remove old autodetection logic and add validation
- update docs and README for new usage
- add shell completion scripts
- add tests for new CLI behaviour
- note breaking change in `CHANGELOG`

## Testing
- `pre-commit run --files tests/test_cli_compress.py compact_memory/cli.py README.md docs/cli_reference.md docs/tutorials/02_building_a_simple_strategy.md docs/tutorials/03_packaging_a_strategy.md docs/SHARING_STRATEGIES.md CHANGELOG.md completions/compact-memory.bash completions/compact-memory.zsh completions/compact-memory.fish`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bb816f3c83299c5e226d4b472215