### PR TITLE
Improve CLI compress tests

### DIFF
--- a/tests/test_cli_compress.py
+++ b/tests/test_cli_compress.py
@@ -1,6 +1,36 @@
 from pathlib import Path
+import json
 from typer.testing import CliRunner
 from compact_memory.cli import app
+from compact_memory.compression import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+    register_compression_strategy,
+)
+
+
+class DummyTruncStrategy(CompressionStrategy):
+    id = "dummy_trunc"
+
+    def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+        text = (
+            text_or_chunks
+            if isinstance(text_or_chunks, str)
+            else " ".join(text_or_chunks)
+        )
+        truncated = text[:llm_token_budget]
+        return CompressedMemory(text=truncated), CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={"llm_token_budget": llm_token_budget},
+            input_summary={"input_length": len(text)},
+            steps=[{"type": "truncate"}],
+            output_summary={"final_length": len(truncated)},
+            final_compressed_object_preview=truncated,
+        )
+
+
+register_compression_strategy(DummyTruncStrategy.id, DummyTruncStrategy)
 
 
 def _env(tmp_path: Path) -> dict[str, str]:
@@ -116,3 +146,228 @@ def test_compress_invalid_combo(tmp_path: Path):
     )
     assert result.exit_code != 0
     assert "specify exactly ONE" in result.stderr
+
+
+def test_compress_file_output_file(tmp_path: Path):
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("sample text")
+    out_path = tmp_path / "out.txt"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--file",
+            str(file_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "100",
+            "-o",
+            str(out_path),
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert out_path.read_text() == "sample text"
+
+
+def test_compress_file_invalid_recursive(tmp_path: Path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("text")
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--file",
+            str(file_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "5",
+            "--recursive",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code != 0
+    assert "--recursive is only valid with --dir" in result.stderr
+
+
+def test_compress_dir_pattern_and_output(tmp_path: Path):
+    dir_path = tmp_path / "data"
+    dir_path.mkdir()
+    (dir_path / "a.txt").write_text("a")
+    (dir_path / "b.md").write_text("b")
+    sub = dir_path / "sub"
+    sub.mkdir()
+    (sub / "c.txt").write_text("c")
+    out_dir = tmp_path / "out"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--dir",
+            str(dir_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "10",
+            "--recursive",
+            "--pattern",
+            "*.txt",
+            "--output-dir",
+            str(out_dir),
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert (out_dir / "a.txt").exists()
+    assert (out_dir / "sub" / "c.txt").exists()
+    assert not (out_dir / "b.md").exists()
+
+
+def test_compress_invalid_strategy(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "hello",
+            "--strategy",
+            "bogus",
+            "--budget",
+            "5",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code != 0
+    assert "Unknown compression strategy" in result.stderr
+
+
+def test_compress_budget_truncation(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "abcdef",
+            "--strategy",
+            DummyTruncStrategy.id,
+            "--budget",
+            "2",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "ab"
+
+
+def test_compress_output_trace(tmp_path: Path):
+    trace_path = tmp_path / "trace.json"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "hi there",
+            "--strategy",
+            "none",
+            "--budget",
+            "10",
+            "--output-trace",
+            str(trace_path),
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    data = json.loads(trace_path.read_text())
+    assert data["strategy_name"] == "none"
+
+
+def test_compress_verbose_stats(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "hello world",
+            "--strategy",
+            "none",
+            "--budget",
+            "20",
+            "--verbose-stats",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert "Original tokens" in result.stdout
+    assert "Compressed tokens" in result.stdout
+
+
+def test_compress_nonexistent_file(tmp_path: Path):
+    file_path = tmp_path / "missing.txt"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--file",
+            str(file_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "5",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--file'" in result.stderr
+
+
+def test_compress_nonexistent_dir(tmp_path: Path):
+    dir_path = tmp_path / "nope"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--dir",
+            str(dir_path),
+            "--strategy",
+            "none",
+            "--budget",
+            "5",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--dir'" in result.stderr
+
+
+def test_compress_uses_default_strategy(tmp_path: Path):
+    env = _env(tmp_path)
+    env["COMPACT_MEMORY_DEFAULT_STRATEGY_ID"] = "none"
+    result = runner.invoke(
+        app,
+        ["compress", "--text", "foobar", "--budget", "10"],
+        env=env,
+    )
+    assert result.exit_code == 0
+    assert "foobar" in result.stdout
+
+
+def test_compress_override_default_strategy(tmp_path: Path):
+    env = _env(tmp_path)
+    env["COMPACT_MEMORY_DEFAULT_STRATEGY_ID"] = DummyTruncStrategy.id
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            "--text",
+            "abcdef",
+            "--strategy",
+            "none",
+            "--budget",
+            "10",
+        ],
+        env=env,
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "abcdef"


### PR DESCRIPTION
## Summary
- add DummyTruncStrategy for CLI tests
- exercise writing to files and directories
- cover invalid flag usage and strategy selection
- check verbose stats, output traces, default strategy, and path errors

## Testing
- `pre-commit run --files tests/test_cli_compress.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bf4b8b488329b8ee3d23080a6cd5