### PR TITLE
Remove LegacyCompressionStrategy alias

### DIFF
--- a/compact_memory/compression.py
+++ b/compact_memory/compression.py
@@ -59,10 +59,6 @@ def all_strategy_metadata() -> Dict[str, Dict[str, Opt[str]]]:
     return dict(_COMPRESSION_INFO)
 
 
-# Maintain alias for backward compatibility
-LegacyCompressionStrategy = CompressionStrategy
-
-
 class NoCompression(CompressionStrategy):
     """Simple strategy that joins turns and truncates."""
 


### PR DESCRIPTION
## Summary
- remove `LegacyCompressionStrategy` alias from compression utilities

## Testing
- `pre-commit run --files compact_memory/compression.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c1c7542c8329847fc5c5941c0583