### PR TITLE
Add isolated tests for plugin loader and package utils

### DIFF
--- a/tests/test_package_utils.py
+++ b/tests/test_package_utils.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from compact_memory.package_utils import (
+    load_strategy_class_from_module,
+    validate_package_dir,
+    check_requirements_installed,
+)
+from compact_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+
+
+def _write_strategy_module(path: Path) -> None:
+    path.write_text(
+        """
+from compact_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+
+class DummyStrategy(CompressionStrategy):
+    id = 'dummy_module'
+
+    def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+        return CompressedMemory(text='ok'), CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={},
+            input_summary={},
+            steps=[],
+        )
+"""
+    )
+
+
+def test_load_strategy_class_from_module(tmp_path: Path) -> None:
+    module_file = tmp_path / "strategy.py"
+    _write_strategy_module(module_file)
+    cls = load_strategy_class_from_module(str(module_file), "DummyStrategy")
+    assert issubclass(cls, CompressionStrategy)
+    inst = cls()
+    mem, trace = inst.compress("text", 10)
+    assert isinstance(mem, CompressedMemory)
+    assert trace.strategy_name == "dummy_module"
+
+
+def test_validate_package_dir(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    module_file = pkg / "strategy.py"
+    _write_strategy_module(module_file)
+    manifest = pkg / "strategy_package.yaml"
+    manifest.write_text(
+        """
+package_format_version: '1.0'
+strategy_id: dummy_module
+strategy_class_name: DummyStrategy
+strategy_module: strategy
+display_name: Dummy Package
+version: '0.1'
+authors: ['Tester']
+description: Test package
+"""
+    )
+    errors, warnings = validate_package_dir(pkg)
+    assert errors == []
+    assert "requirements.txt not found" in warnings
+
+
+def test_check_requirements_installed(tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("nonexistent_pkg_xyz>=1.0")
+    missing = check_requirements_installed(req)
+    assert missing == ["nonexistent_pkg_xyz"]

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+
+from compact_memory.compression.registry import (
+    _COMPRESSION_REGISTRY,
+    _COMPRESSION_INFO,
+    get_strategy_metadata,
+)
+from compact_memory.plugin_loader import load_plugins, PLUGIN_ENV_VAR
+
+
+def _create_plugin(pkg_dir: Path) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "strategy.py").write_text(
+        """
+from compact_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
+
+class DummyPluginStrategy(CompressionStrategy):
+    id = 'dummy_plugin'
+
+    def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+        return CompressedMemory(text='x'), CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={},
+            input_summary={},
+            steps=[],
+        )
+"""
+    )
+    (pkg_dir / "strategy_package.yaml").write_text(
+        """
+package_format_version: '1.0'
+strategy_id: dummy_plugin
+strategy_class_name: DummyPluginStrategy
+strategy_module: strategy
+display_name: Dummy Plugin
+version: '0.1'
+authors: ['Tester']
+description: Test plugin
+"""
+    )
+
+
+def test_load_local_plugin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _create_plugin(plugin_dir)
+    monkeypatch.setenv(PLUGIN_ENV_VAR, str(tmp_path))
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda *a, **k: [])
+    import compact_memory.plugin_loader as pl
+
+    pl._loaded = False
+    _COMPRESSION_REGISTRY.pop("dummy_plugin", None)
+    _COMPRESSION_INFO.pop("dummy_plugin", None)
+    load_plugins()
+    assert "dummy_plugin" in _COMPRESSION_REGISTRY
+    info = get_strategy_metadata("dummy_plugin")
+    assert info and info["source"].startswith("local")
+    _COMPRESSION_REGISTRY.pop("dummy_plugin", None)
+    _COMPRESSION_INFO.pop("dummy_plugin", None)
+    pl._loaded = False


### PR DESCRIPTION
## Summary
- add tests for package utilities using temporary modules
- add plugin loader test that simulates a local plugin

## Testing
- `pre-commit run --files tests/test_package_utils.py tests/test_plugin_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c6b2779883299f1cb39c370c70d0