### PR TITLE
Add entrypoint plugin loader test

### DIFF
--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -8,6 +8,11 @@ from compact_memory.compression.registry import (
     get_strategy_metadata,
 )
 from compact_memory.plugin_loader import load_plugins, PLUGIN_ENV_VAR
+from compact_memory.compression.strategies_abc import (
+    CompressionStrategy,
+    CompressedMemory,
+    CompressionTrace,
+)
 
 
 def _create_plugin(pkg_dir: Path) -> None:
@@ -62,4 +67,48 @@ def test_load_local_plugin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     assert info and info["source"].startswith("local")
     _COMPRESSION_REGISTRY.pop("dummy_plugin", None)
     _COMPRESSION_INFO.pop("dummy_plugin", None)
+    pl._loaded = False
+
+
+def test_load_entrypoint_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyEPStrategy(CompressionStrategy):
+        id = "dummy_ep"
+
+        def compress(self, text_or_chunks, llm_token_budget, **kwargs):
+            return CompressedMemory(text="y"), CompressionTrace(
+                strategy_name=self.id,
+                strategy_params={},
+                input_summary={},
+                steps=[],
+            )
+
+    class DummyEP:
+        def __init__(self, value: str, obj: type[CompressionStrategy]):
+            self.value = value
+            self._obj = obj
+            self.dist = type(
+                "Dist", (), {"metadata": {"Name": "dummy"}, "version": "0.1"}
+            )()
+
+        def load(self):  # pragma: no cover - executed during test
+            return self._obj
+
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points",
+        lambda *a, **k: [DummyEP("dummy:DummyEPStrategy", DummyEPStrategy)],
+    )
+    monkeypatch.setattr(
+        "compact_memory.plugin_loader._iter_local_plugin_paths", lambda: []
+    )
+    import compact_memory.plugin_loader as pl
+
+    pl._loaded = False
+    _COMPRESSION_REGISTRY.pop("dummy_ep", None)
+    _COMPRESSION_INFO.pop("dummy_ep", None)
+    load_plugins()
+    assert "dummy_ep" in _COMPRESSION_REGISTRY
+    info = get_strategy_metadata("dummy_ep")
+    assert info and info["source"].startswith("plugin")
+    _COMPRESSION_REGISTRY.pop("dummy_ep", None)
+    _COMPRESSION_INFO.pop("dummy_ep", None)
     pl._loaded = False


### PR DESCRIPTION
## Summary
- test plugin loading via entry points

## Testing
- `pre-commit run --files tests/test_plugin_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ccf06830832980be664c0c7f0a03