### PR TITLE
Enhance compression trace checks

### DIFF
--- a/tests/test_cli_compress.py
+++ b/tests/test_cli_compress.py
@@ -281,6 +281,9 @@ def test_compress_output_trace(tmp_path: Path):
     assert result.exit_code == 0
     data = json.loads(trace_path.read_text())
     assert data["strategy_name"] == "none"
+    for key in ["strategy_params", "input_summary", "output_summary", "steps"]:
+        assert key in data
+    assert data["output_summary"]["output_length"] == len("hi there")
 
 
 def test_compress_verbose_stats(tmp_path: Path):

--- a/tests/test_compression_strategies.py
+++ b/tests/test_compression_strategies.py
@@ -65,6 +65,15 @@ def test_pipeline_strategy_executes_in_order():
     )
     assert compressed.text == "alpha bravo"[:5]
     assert len(trace.steps) == 2
+    assert trace.output_summary["output_length"] == len(compressed.text)
+    for step in trace.steps:
+        assert step["strategy"] == DummyStrategy.id
+        inner_trace = step["trace"]
+        assert isinstance(inner_trace, CompressionTrace)
+        assert inner_trace.strategy_name == DummyStrategy.id
+        assert inner_trace.output_summary["final_length"] == len(
+            inner_trace.final_compressed_object_preview
+        )
 
 
 def test_pipeline_strategy_config_instantiates_from_registry():


### PR DESCRIPTION
## Summary
- verify more details in compression traces during pipeline compression
- check additional fields when CLI writes a trace file

## Testing
- `pre-commit run --files tests/test_compression_strategies.py tests/test_cli_compress.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cd3de4dc83298c9b0775fff8f083