### PR TITLE
Load experimental strategies automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,17 @@ Note: The old method of enabling strategies via `compact_memory_config.yaml` dir
 
 ### Using Experimental Strategies
 
-Experimental strategies are available under ``compact_memory.strategies.experimental``.
-They are not registered by default.
+Experimental strategies live under ``compact_memory.strategies.experimental``.
+The CLI registers them automatically, so commands like ``--strategy first_last`` work out of the box.
+When using the Python API directly, call ``enable_all_experimental_strategies()`` to register them:
 
 ```python
-from compact_memory.compression import register_compression_strategy
-from compact_memory.strategies.experimental import ChainedStrategy
+from compact_memory.strategies.experimental import (
+    ChainedStrategy,
+    enable_all_experimental_strategies,
+)
 
-register_compression_strategy("chained", ChainedStrategy)
+enable_all_experimental_strategies()
 ```
 
 Once registered, these strategies behave like any other:

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,6 +4,8 @@ This guide shows how to use the Compact Memory toolkit from the command line and
 
 ## Basic CLI Usage
 
+The CLI automatically registers the experimental strategies, so options like `first_last` work without extra setup.
+
 Compress a text file using the `first_last` strategy with a token budget of 100:
 
 ```bash

--- a/compact_memory/cli.py
+++ b/compact_memory/cli.py
@@ -24,7 +24,10 @@ from .logging_utils import configure_logging
 from .agent import Agent
 from .vector_store import InMemoryVectorStore
 from . import local_llm
-from .strategies.experimental import ActiveMemoryManager
+from .strategies.experimental import (
+    ActiveMemoryManager,
+    enable_all_experimental_strategies,
+)
 from .registry import (
     _VALIDATION_METRIC_REGISTRY,
     get_validation_metric_class,
@@ -215,6 +218,7 @@ def main(
             raise typer.Exit(code=1)
 
     load_plugins()
+    enable_all_experimental_strategies()
 
     # ctx.obj['config'] is already set above
     ctx.obj.update(
@@ -969,6 +973,7 @@ def list_strategies(
 ) -> None:
     """Displays a table of registered compression strategies."""
     load_plugins()  # Ensure plugins are loaded
+    enable_all_experimental_strategies()
     if include_contrib:
         try:
             from contrib import enable_all_contrib_strategies

--- a/compact_memory/strategies/experimental/__init__.py
+++ b/compact_memory/strategies/experimental/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "PrototypeSystemStrategy",
     "EvidenceWriter",
     "LLMSummarisingChunker",
+    "enable_all_experimental_strategies",
 ]
 
 _lazy_modules = {
@@ -41,3 +42,12 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - passthrough
 
 def __dir__() -> list[str]:  # pragma: no cover
     return sorted(list(globals().keys()) + list(_lazy_modules.keys()))
+
+
+def enable_all_experimental_strategies() -> None:
+    """Register all experimental compression strategies."""
+    for module in _lazy_modules.values():
+        try:
+            importlib.import_module(__name__ + module)
+        except Exception:  # pragma: no cover - optional modules may fail
+            continue


### PR DESCRIPTION
## Summary
- add helper to enable all experimental strategies
- auto-enable them in the CLI
- update docs describing that CLI now loads experimental strategies

## Testing
- `pre-commit run --files compact_memory/strategies/experimental/__init__.py compact_memory/cli.py README.md USAGE.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d7d4846c8329a60f654557a5efa6