### PR TITLE
Fix leftover gist references

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,12 +305,13 @@ You can manage the user global configuration using the `config` commands:
 
 For example, to set your default memory path globally:
 ```bash
-compact-memory config set compact_memory_path ~/my_gist_memories
+# Set a default directory for your stored memories
+compact-memory config set compact_memory_path ~/my_compact_memories
 # Subsequent commands will use this path unless overridden by --memory-path or an environment variable.
 ```
 Or, set it using an environment variable for the current session:
 ```bash
-export COMPACT_MEMORY_PATH=~/my_gist_memories
+export COMPACT_MEMORY_PATH=~/my_compact_memories
 ```
 
 ## Quick Start / Core Workflow

--- a/compact_memory/package_utils.py
+++ b/compact_memory/package_utils.py
@@ -58,7 +58,7 @@ def load_strategy_class_from_module(
     if not module_path.exists():
         raise FileNotFoundError(f"Module file not found: {module_file_path}")
 
-    unique_name = f"gistmemory.packages.{module_path.stem}_{uuid.uuid4().hex}"
+    unique_name = f"compact_memory.packages.{module_path.stem}_{uuid.uuid4().hex}"
     spec = importlib.util.spec_from_file_location(unique_name, module_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load module from {module_file_path}")
@@ -79,7 +79,9 @@ def load_strategy_class_from_module(
     return cls
 
 
-def load_strategy_class(package_dir: Path, manifest: Dict[str, Any]) -> type[CompressionStrategy]:
+def load_strategy_class(
+    package_dir: Path, manifest: Dict[str, Any]
+) -> type[CompressionStrategy]:
     module_name = manifest["strategy_module"]
     class_name = manifest["strategy_class_name"]
     module_path = package_dir / f"{module_name}.py"
@@ -149,6 +151,7 @@ def validate_package_dir(package_dir: Path) -> tuple[list[str], list[str]]:
         warnings.append("README.md not found")
 
     return errors, warnings
+
 
 __all__ = [
     "load_manifest",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ You can set default values for key options to avoid typing them repeatedly. Thes
 
 1.  **Set your preferred memory path:**
     ```bash
-    compact-memory config set compact_memory_path "~/gist_memories"
+    compact-memory config set compact_memory_path "~/compact_memories"
     ```
     *(The CLI will expand `~` to your home directory).*
 2.  **Set your default LLM:**
@@ -101,7 +101,7 @@ You can set default values for key options to avoid typing them repeatedly. Thes
 3.  **Initialize an agent (it will now use the default path if not specified):**
     ```bash
     compact-memory agent init
-    # If "~/gist_memories" does not exist, it will be created.
+    # If "~/compact_memories" does not exist, it will be created.
     # If it exists and is a valid agent, this might show an error unless it's empty or a different path is given.
     # Typically, you initialize to a specific new path first:
     # compact-memory agent init ./my_specific_agent_location


### PR DESCRIPTION
## Summary
- remove old gistmemory package prefix
- update documentation to use `my_compact_memories` path

## Testing
- `pre-commit run --files README.md compact_memory/package_utils.py docs/configuration.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840e4c0871c8329810c8f6e92821795