### PR TITLE
Make heavy dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,18 @@ This project requires **Python 3.11+**.
 
 1.  **Install Core Dependencies:** Use the provided `setup.sh` for a fast install.
    ```bash
-   bash setup.sh           # installs the minimal set of packages
-   # Download the spaCy model for sentence segmentation (used by some strategies/chunkers)
-   python -m spacy download en_core_web_sm
+   bash setup.sh           # installs only the lightweight requirements
    ```
-   If you need to run the full test suite (which depends on PyTorch and other
-   heavy packages), run:
+   Optional features such as spaCy sentence segmentation or local models
+   require extra dependencies. Install them with pip extras, e.g.:
+   ```bash
+   pip install .[spacy]        # for robust sentence segmentation
+   pip install .[embedding]    # to enable embedding pipelines
+   pip install .[local]        # for local Transformers models
+   pip install .[gemini]       # Google Gemini provider
+   pip install .[metrics]      # Hugging Face evaluation metrics
+   ```
+   To run the full test suite with all heavy packages:
    ```bash
    FULL_INSTALL=1 bash setup.sh
    ```

--- a/compact_memory/llm_providers/gemini_provider.py
+++ b/compact_memory/llm_providers/gemini_provider.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Dict
 import os
 
-import google.generativeai as genai
 
 from ..llm_providers_abc import LLMProvider
 
@@ -20,6 +19,12 @@ class GeminiProvider(LLMProvider):
         return self.MODEL_TOKEN_LIMITS.get(model_name, default)
 
     def count_tokens(self, text: str, model_name: str, **kwargs) -> int:
+        try:
+            import google.generativeai as genai
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "google-generativeai is required for GeminiProvider"
+            ) from exc
         model = genai.GenerativeModel(model_name)
         return model.count_tokens(text).total_tokens
 
@@ -33,6 +38,12 @@ class GeminiProvider(LLMProvider):
         api_key = llm_kwargs.pop("api_key", None)
         if api_key is None:
             api_key = os.getenv("GEMINI_API_KEY")
+        try:
+            import google.generativeai as genai
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "google-generativeai is required for GeminiProvider"
+            ) from exc
         if api_key:
             genai.configure(api_key=api_key)
         model = genai.GenerativeModel(model_name)

--- a/compact_memory/spacy_utils.py
+++ b/compact_memory/spacy_utils.py
@@ -8,19 +8,38 @@ _lock = threading.Lock()
 _nlp = None
 
 
+class _SimpleNLP:
+    """Fallback spaCy-like object using regex sentence splitting."""
+
+    pipe_names: list[str] = []
+
+    def __call__(self, text: str):
+        sentences = simple_sentences(text)
+
+        class _Doc:
+            def __init__(self, sents: list[str]):
+                self.sents = [type("Span", (), {"text": s})() for s in sents]
+
+        return _Doc(sentences)
+
+
 def get_nlp():
     """Load and return the shared spaCy model."""
     global _nlp
     if _nlp is None:
         with _lock:
             if _nlp is None:
-                import spacy
                 try:
-                    _nlp = spacy.load(_MODEL_NAME)
-                except Exception:  # pragma: no cover - fallback path
-                    nlp = spacy.blank("en")
-                    nlp.add_pipe("sentencizer")
-                    _nlp = nlp
+                    import spacy
+                except Exception:  # pragma: no cover - spaCy not installed
+                    _nlp = _SimpleNLP()
+                else:
+                    try:
+                        _nlp = spacy.load(_MODEL_NAME)
+                    except Exception:  # pragma: no cover - fallback path
+                        nlp = spacy.blank("en")
+                        nlp.add_pipe("sentencizer")
+                        _nlp = nlp
     return _nlp
 
 

--- a/docs/DEVELOPING_VALIDATION_METRICS.md
+++ b/docs/DEVELOPING_VALIDATION_METRICS.md
@@ -29,7 +29,8 @@ register_validation_metric(MyMetric.metric_id, MyMetric)
 ## Hugging Face evaluate Metrics
 
 Metrics backed by the [`evaluate`](https://github.com/huggingface/evaluate)
-library can extend `HFValidationMetric` which handles loading the metric:
+library can extend `HFValidationMetric` which handles loading the metric.
+Install the optional dependency with `pip install compact-memory[metrics]`:
 
 ```python
 from compact_memory.validation.hf_metrics import HFValidationMetric

--- a/docs/tutorials/02_building_a_simple_strategy.md
+++ b/docs/tutorials/02_building_a_simple_strategy.md
@@ -3,7 +3,8 @@ This tutorial walks you through creating a basic compression strategy for Compac
 ## Prerequisites
 *   `Compact Memory installed (\`pip install compact-memory\`).`
 *   `Familiarity with Python.`
-*   `(Optional but recommended) \`spaCy\` for sentence tokenization: \`python -m spacy download en_core_web_sm\``
+*   `(Optional but recommended)` install the spaCy extra for robust sentence tokenization:
+    `pip install compact-memory[spacy] && python -m spacy download en_core_web_sm`
 ## Goal
 Our strategy, \`FirstNSentencesStrategy\`, will:
 1.  `Take a piece of text as input.`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,9 @@ dependencies = [
     "tqdm",
     "pydantic",
     "pyyaml",
-    "sentence-transformers",
-    "transformers",
-    "spacy",
     "typer[all]>=0.16.0",
     "portalocker",
     "rich>=13.6",
-    "google-generativeai",
-    "evaluate",
 ]
 
 [project.optional-dependencies]
@@ -34,6 +29,10 @@ chroma = ["chromadb"]
 spacy = ["spacy"]
 optuna = ["optuna"]
 ray = ["ray[tune]"]
+embedding = ["sentence-transformers", "torch"]
+local = ["transformers", "torch"]
+gemini = ["google-generativeai"]
+metrics = ["evaluate"]
 
 [project.scripts]
 compact-memory = "compact_memory.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,7 @@ tqdm
 pydantic
 pyyaml
 pytest
-sentence-transformers
-transformers
 rich>=13.6
-spacy
 typer[all]>=0.16.0
 portalocker
-google-generativeai
-evaluate
 flake8

--- a/setup.sh
+++ b/setup.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 
 pip install --prefer-binary \
     openai tiktoken numpy faiss-cpu click>=8.2 tqdm pydantic \
-    pyyaml transformers spacy "typer[all]>=0.16.0" portalocker \
-    "rich>=13.6"
+    pyyaml "typer[all]>=0.16.0" portalocker "rich>=13.6"
 
 # Optional heavy dependencies required for the full test suite
 if [[ "${FULL_INSTALL:-0}" == "1" ]]; then
-    pip install torch sentence-transformers google-generativeai evaluate
+    pip install torch sentence-transformers transformers spacy \
+        google-generativeai evaluate
 fi
 # Install project without automatically pulling optional heavy deps
 pip install -e . --no-build-isolation --no-deps


### PR DESCRIPTION
## Summary
- lighten default installation by removing heavy libraries from `pyproject.toml`
- add optional extras for embeddings, local models, Gemini and HF metrics
- update install instructions in README
- document optional extras in developer docs
- handle missing spaCy with a small fallback implementation
- lazily import transformers and google-generativeai
- adjust setup script and requirements list

## Testing
- `pre-commit run --files README.md compact_memory/learned_summarizer_strategy.py compact_memory/llm_providers/gemini_provider.py compact_memory/spacy_utils.py docs/DEVELOPING_VALIDATION_METRICS.md docs/tutorials/02_building_a_simple_strategy.md pyproject.toml requirements.txt setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e70ff1ec8329b751b4d240dfa986