### PR TITLE
Add compression engine package

### DIFF
--- a/CompressionStrategy/core/strategies_abc.py
+++ b/CompressionStrategy/core/strategies_abc.py
@@ -3,26 +3,9 @@ from __future__ import annotations
 """Abstract interface for memory compression strategies."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Dict, List, Union, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from .trace import CompressionTrace
-
-
-@dataclass
-class CompressedMemory:
-    """
-    Simple container for compressed memory text and associated metadata.
-
-    Attributes:
-        text: The compressed string output from a compression strategy.
-        metadata: An optional dictionary to hold any additional information
-                  about the compressed content, such as source IDs, timestamps,
-                  or strategy-specific details.
-    """
-
-    text: str
-    metadata: Optional[Dict[str, Any]] = None
+from compact_memory.engines import CompressedMemory, CompressionTrace
 
 
 class CompressionStrategy(ABC):

--- a/CompressionStrategy/core/trace.py
+++ b/CompressionStrategy/core/trace.py
@@ -2,49 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
-
-
-@dataclass
-class CompressionTrace:
-    """
-    Represents the chain-of-thought and operational log of a CompressionStrategy.
-
-    This data structure is used to record the inputs, outputs, intermediate steps,
-    and performance metrics of a compression process. It is invaluable for
-    debugging, analyzing strategy behavior, and understanding the impact of
-    different parameters or techniques.
-
-    Attributes:
-        strategy_name: The `id` of the `CompressionStrategy` used.
-        strategy_params: A dictionary of parameters with which the strategy was
-                         configured or called for this specific compression task.
-        input_summary: A dictionary summarizing the input to the compression.
-                       Common keys include `original_length` (e.g., character count)
-                       and `original_tokens` (if a tokenizer was used).
-        steps: A list of dictionaries, where each dictionary represents a distinct
-               step or operation performed by the strategy during compression.
-               Each step entry should ideally have a 'type' field (e.g., "chunking",
-               "summarization_llm_call", "filtering") and a 'details' field
-               containing relevant information about that step (e.g., number of
-               chunks created, prompt sent to LLM, items filtered out).
-        output_summary: A dictionary summarizing the output of the compression.
-                        Common keys include `compressed_length` (e.g., character count)
-                        and `compressed_tokens` (if a tokenizer was used).
-        processing_ms: The total time taken for the compression process, in milliseconds.
-                       This should be populated by the strategy if possible.
-        final_compressed_object_preview: A short string preview of the final
-                                         compressed text, useful for quick inspection in logs.
-    """
-
-    strategy_name: str
-    strategy_params: Dict[str, Any]
-    input_summary: Dict[str, Any]
-    steps: List[Dict[str, Any]] = field(default_factory=list)
-    output_summary: Dict[str, Any] = field(default_factory=dict)
-    processing_ms: float | None = None
-    final_compressed_object_preview: Optional[str] = None
+from compact_memory.engines import CompressionTrace
 
 
 __all__ = ["CompressionTrace"]

--- a/compact_memory/__init__.py
+++ b/compact_memory/__init__.py
@@ -29,6 +29,9 @@ __all__ = [
     "PromptBudget",
     "CompressionStrategy",
     "NoCompression",
+    "BaseCompressionEngine",
+    "CompressedMemory",
+    "CompressionTrace",
     "ValidationMetric",
     "StrategyConfig",
 ]
@@ -57,6 +60,9 @@ _lazy_map = {
     "PromptBudget": "compact_memory.prompt_budget",
     "CompressionStrategy": "CompressionStrategy.core",
     "NoCompression": "CompressionStrategy.core",
+    "BaseCompressionEngine": "compact_memory.engines",
+    "CompressedMemory": "compact_memory.engines",
+    "CompressionTrace": "compact_memory.engines",
     "ValidationMetric": "compact_memory.validation.metrics_abc",
     "StrategyConfig": "CompressionStrategy.core",
 }

--- a/compact_memory/engines/__init__.py
+++ b/compact_memory/engines/__init__.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+"""Compression engine utilities and dataclasses."""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+import json
+import os
+import uuid
+
+import numpy as np
+import faiss
+
+from ..chunker import SentenceWindowChunker
+from ..embedding_pipeline import embed_text, get_embedding_dim
+
+
+@dataclass
+class CompressedMemory:
+    """Container for compressed text and metadata."""
+
+    text: str
+    metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CompressionTrace:
+    """Trace metadata for a compression operation."""
+
+    strategy_name: str
+    strategy_params: Dict[str, Any]
+    input_summary: Dict[str, Any]
+    steps: List[Dict[str, Any]] = field(default_factory=list)
+    output_summary: Dict[str, Any] = field(default_factory=dict)
+    processing_ms: float | None = None
+    final_compressed_object_preview: Optional[str] = None
+
+
+class BaseCompressionEngine:
+    """Simple retrieval engine using MiniLM embeddings and FAISS."""
+
+    def __init__(
+        self,
+        *,
+        chunker: SentenceWindowChunker | None = None,
+        embedding_fn: Callable[[str | Sequence[str]], np.ndarray] = embed_text,
+        preprocess_fn: Callable[[str], str] | None = None,
+    ) -> None:
+        self.chunker = chunker or SentenceWindowChunker()
+        self.embedding_fn = embedding_fn
+        self.preprocess_fn = preprocess_fn
+        self.memories: List[Dict[str, Any]] = []
+        dim = get_embedding_dim()
+        self.embeddings = np.zeros((0, dim), dtype=np.float32)
+        self.index: faiss.IndexFlatIP | None = None
+
+    # --------------------------------------------------
+    def _ensure_index(self) -> None:
+        if self.index is None and self.embeddings.size:
+            self.index = faiss.IndexFlatIP(self.embeddings.shape[1])
+            self.index.add(self.embeddings.astype(np.float32))
+
+    # --------------------------------------------------
+    def ingest(self, text: str) -> List[str]:
+        """Chunk and store ``text`` in the engine."""
+
+        chunks = self.chunker.chunk(text)
+        if not chunks:
+            return []
+        vecs = self.embedding_fn(chunks, preprocess_fn=self.preprocess_fn)
+        if vecs.ndim == 1:
+            vecs = vecs.reshape(1, -1)
+        ids: List[str] = []
+        for chunk, vec in zip(chunks, vecs):
+            mid = uuid.uuid4().hex
+            self.memories.append({"id": mid, "text": chunk})
+            self.embeddings = np.vstack([self.embeddings, vec.astype(np.float32)])
+            ids.append(mid)
+        if self.index is None:
+            self.index = faiss.IndexFlatIP(self.embeddings.shape[1])
+        self.index.add(vecs.astype(np.float32))
+        return ids
+
+    # --------------------------------------------------
+    def recall(self, query: str, *, top_k: int = 5) -> List[Dict[str, Any]]:
+        """Retrieve memories most similar to ``query``."""
+
+        if not self.memories:
+            return []
+        self._ensure_index()
+        qvec = self.embedding_fn(query, preprocess_fn=self.preprocess_fn)
+        qvec = qvec.reshape(1, -1).astype(np.float32)
+        k = min(top_k, len(self.memories))
+        dists, idxs = self.index.search(qvec, k)
+        results: List[Dict[str, Any]] = []
+        for idx, dist in zip(idxs[0], dists[0]):
+            if idx < 0:
+                continue
+            mem = self.memories[int(idx)]
+            results.append({"id": mem["id"], "text": mem["text"], "score": float(dist)})
+        return results
+
+    # --------------------------------------------------
+    def compress(
+        self, text: str, budget: int
+    ) -> tuple[CompressedMemory, CompressionTrace]:
+        """Naive compression via truncation."""
+
+        truncated = text[:budget]
+        trace = CompressionTrace(
+            strategy_name="base_truncate",
+            strategy_params={"budget": budget},
+            input_summary={"original_length": len(text)},
+            steps=[{"type": "truncate", "details": {"budget": budget}}],
+            output_summary={"compressed_length": len(truncated)},
+        )
+        return CompressedMemory(text=truncated), trace
+
+    # --------------------------------------------------
+    def save(self, path: str) -> None:
+        """Persist memories and embeddings to ``path``."""
+
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "entries.json"), "w", encoding="utf-8") as fh:
+            json.dump(self.memories, fh)
+        np.save(os.path.join(path, "embeddings.npy"), self.embeddings)
+
+    # --------------------------------------------------
+    def load(self, path: str) -> None:
+        """Load engine state from ``path``."""
+
+        with open(os.path.join(path, "entries.json"), "r", encoding="utf-8") as fh:
+            self.memories = json.load(fh)
+        self.embeddings = np.load(os.path.join(path, "embeddings.npy"))
+        self.index = None
+        self._ensure_index()
+
+
+__all__ = ["BaseCompressionEngine", "CompressedMemory", "CompressionTrace"]

--- a/tests/test_base_engine.py
+++ b/tests/test_base_engine.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from compact_memory.engines import BaseCompressionEngine
+
+
+def test_engine_ingest_and_recall(patch_embedding_model):
+    engine = BaseCompressionEngine()
+    ids = engine.ingest("A cat sits. A dog runs.")
+    assert len(ids) >= 1
+    results = engine.recall("cat", top_k=1)
+    assert results
+    assert "cat" in results[0]["text"]
+
+
+def test_engine_save_load(tmp_path: Path, patch_embedding_model):
+    engine = BaseCompressionEngine()
+    engine.ingest("Hello world.")
+    engine.save(tmp_path)
+
+    other = BaseCompressionEngine()
+    other.load(tmp_path)
+    res = other.recall("Hello")
+    assert res
+    # ensure files exist
+    assert (tmp_path / "entries.json").exists()
+    assert (tmp_path / "embeddings.npy").exists()


### PR DESCRIPTION
## Summary
- move `CompressedMemory` and `CompressionTrace` to new `compact_memory.engines`
- implement `BaseCompressionEngine` with MiniLM embeddings, FAISS retrieval, and persistence
- export engine classes from package init for easy import
- update `CompressionStrategy` modules to use the moved dataclasses
- test `BaseCompressionEngine` ingest, recall, save and load

## Testing
- `pre-commit run --files compact_memory/engines/__init__.py CompressionStrategy/core/strategies_abc.py CompressionStrategy/core/trace.py compact_memory/__init__.py tests/test_base_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418d4deb588329b4a9b4d1df191d9f