### PR TITLE
Add plugin engine save/load test

### DIFF
--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -5,6 +5,7 @@ from compact_memory.engine_registry import (
     _ENGINE_REGISTRY,
     _ENGINE_INFO,
     get_engine_metadata,
+    available_engines,
 )
 from compact_memory.plugin_loader import load_plugins, PLUGIN_ENV_VAR
 from compact_memory.engines import (
@@ -106,4 +107,37 @@ def test_load_entrypoint_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
     assert info and info["source"].startswith("plugin")
     _ENGINE_REGISTRY.pop("dummy_ep", None)
     _ENGINE_INFO.pop("dummy_ep", None)
+    pl._loaded = False
+
+
+def test_plugin_engine_save_load(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, patch_embedding_model
+) -> None:
+    """Engine from plugin should support save/load round trip."""
+    plugin_dir = tmp_path / "plugin"
+    _create_plugin(plugin_dir)
+    monkeypatch.setenv(PLUGIN_ENV_VAR, str(tmp_path))
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda *a, **k: [])
+
+    import compact_memory.plugin_loader as pl
+
+    pl._loaded = False
+    _ENGINE_REGISTRY.pop("dummy_plugin", None)
+    _ENGINE_INFO.pop("dummy_plugin", None)
+    load_plugins()
+    assert "dummy_plugin" in available_engines()
+
+    cls = _ENGINE_REGISTRY["dummy_plugin"]
+    engine = cls()
+    engine.ingest("cats and dogs")
+    save_path = tmp_path / "eng"
+    engine.save(save_path)
+
+    other = cls()
+    other.load(save_path)
+    results = other.recall("dogs", top_k=1)
+    assert results and "dogs" in results[0]["text"]
+
+    _ENGINE_REGISTRY.pop("dummy_plugin", None)
+    _ENGINE_INFO.pop("dummy_plugin", None)
     pl._loaded = False


### PR DESCRIPTION
## Summary
- verify plugin engine can be saved and loaded

## Testing
- `pre-commit run --files tests/test_plugin_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a1a940188329a478560607a4d738