### PR TITLE
Refactor exports for engine API

### DIFF
--- a/compact_memory/__init__.py
+++ b/compact_memory/__init__.py
@@ -27,13 +27,19 @@ __all__ = [
     "tokenize_text",
     "token_count",
     "PromptBudget",
-    "CompressionStrategy",
-    "NoCompression",
     "BaseCompressionEngine",
     "CompressedMemory",
     "CompressionTrace",
+    "PipelineEngineConfig",
+    "PipelineEngine",
+    "NoCompressionEngine",
     "ValidationMetric",
     "StrategyConfig",
+    "register_compression_engine",
+    "get_compression_engine",
+    "available_engines",
+    "get_engine_metadata",
+    "all_engine_metadata",
 ]
 
 _lazy_map = {
@@ -58,13 +64,19 @@ _lazy_map = {
     "token_count": "compact_memory.token_utils",
     "LearnedSummarizerStrategy": "CompressionStrategy.contrib.learned_summarizer_strategy",
     "PromptBudget": "compact_memory.prompt_budget",
-    "CompressionStrategy": "CompressionStrategy.core",
-    "NoCompression": "CompressionStrategy.core",
     "BaseCompressionEngine": "compact_memory.engines",
     "CompressedMemory": "compact_memory.engines",
     "CompressionTrace": "compact_memory.engines",
+    "PipelineEngineConfig": "compact_memory.engines.pipeline_engine",
+    "PipelineEngine": "compact_memory.engines.pipeline_engine",
+    "NoCompressionEngine": "compact_memory.engines.no_compression_engine",
     "ValidationMetric": "compact_memory.validation.metrics_abc",
     "StrategyConfig": "CompressionStrategy.core",
+    "register_compression_engine": "compact_memory.engine_registry",
+    "get_compression_engine": "compact_memory.engine_registry",
+    "available_engines": "compact_memory.engine_registry",
+    "get_engine_metadata": "compact_memory.engine_registry",
+    "all_engine_metadata": "compact_memory.engine_registry",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ metrics = ["evaluate"]
 [project.scripts]
 compact-memory = "compact_memory.__main__:main"
 
+[project.entry-points."compact_memory.engines"]
+none = "compact_memory.engines.no_compression_engine:NoCompressionEngine"
+pipeline = "compact_memory.engines.pipeline_engine:PipelineEngine"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["compact_memory", "compact_memory.*", "CompressionStrategy", "CompressionStrategy.*"]


### PR DESCRIPTION
## Summary
- update `compact_memory.__init__` to expose engine classes and registry helpers
- remove old `CompressionStrategy` and `NoCompression` exports
- add entry points for built-in engines in `pyproject.toml`

## Testing
- `pre-commit run --files compact_memory/__init__.py pyproject.toml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841a2c86c9c8329ad6d6cac1e93de39