### PR TITLE
Add FirstLastEngine

### DIFF
--- a/compact_memory/contrib/__init__.py
+++ b/compact_memory/contrib/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 __all__ = [
     "ActiveMemoryEngine",
+    "FirstLastEngine",
     "ActiveMemoryManager",
     "ConversationTurn",
     "enable_all_experimental_engines",
@@ -15,6 +16,7 @@ __all__ = [
 
 _lazy_modules = {
     "ActiveMemoryEngine": "compact_memory.engines.active_memory_engine",
+    "FirstLastEngine": "compact_memory.engines.first_last_engine",
     "ActiveMemoryManager": "compact_memory.active_memory_manager",
     "ConversationTurn": "compact_memory.active_memory_manager",
 }

--- a/compact_memory/engines/first_last_engine.py
+++ b/compact_memory/engines/first_last_engine.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Engine that keeps the first and last chunks of text."""
+
+from typing import List, Union, Any
+
+from . import BaseCompressionEngine, CompressedMemory, CompressionTrace
+from .registry import register_compression_engine
+
+
+class FirstLastEngine(BaseCompressionEngine):
+    """Keep first and last parts of the text within the budget."""
+
+    id = "first_last"
+
+    def compress(
+        self,
+        text_or_chunks: Union[str, List[str]],
+        llm_token_budget: int | None,
+        *,
+        tokenizer: Any = None,
+        **kwargs: Any,
+    ) -> tuple[CompressedMemory, CompressionTrace]:
+        text = (
+            text_or_chunks
+            if isinstance(text_or_chunks, str)
+            else " ".join(text_or_chunks)
+        )
+        if llm_token_budget is None or llm_token_budget <= 0:
+            kept = text
+            half = len(text)
+        else:
+            half = max(llm_token_budget // 2, 0)
+            kept = text[:half] + text[-half:]
+        compressed = CompressedMemory(text=kept)
+        trace = CompressionTrace(
+            strategy_name=self.id,
+            strategy_params={"llm_token_budget": llm_token_budget},
+            input_summary={"input_length": len(text)},
+            steps=[
+                {
+                    "type": "first_last",
+                    "kept_first": len(kept[:half]),
+                    "kept_last": len(kept[half:]),
+                }
+            ],
+            output_summary={"final_length": len(kept)},
+            final_compressed_object_preview=kept[:50],
+        )
+        return compressed, trace
+
+
+register_compression_engine(FirstLastEngine.id, FirstLastEngine, source="contrib")
+
+__all__ = ["FirstLastEngine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ compact-memory = "compact_memory.__main__:main"
 [project.entry-points."compact_memory.engines"]
 none = "compact_memory.engines.no_compression_engine:NoCompressionEngine"
 pipeline = "compact_memory.engines.pipeline_engine:PipelineEngine"
+first_last = "compact_memory.engines.first_last_engine:FirstLastEngine"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- port FirstLastStrategy logic to new FirstLastEngine
- expose engine via contrib utilities
- register entry point in pyproject

## Testing
- `pre-commit run --files compact_memory/engines/first_last_engine.py compact_memory/contrib/__init__.py pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bce0a9c08329a749e956dfff7af7