### PR TITLE
Switch CLI to shared engine loader

### DIFF
--- a/compact_memory/cli.py
+++ b/compact_memory/cli.py
@@ -34,6 +34,7 @@ from .engine_registry import (
     all_engine_metadata,
 )
 from .engines.no_compression_engine import NoCompressionEngine
+from .engines import load_engine
 from .validation.registry import (
     _VALIDATION_METRIC_REGISTRY,
     get_validation_metric_class,
@@ -238,13 +239,6 @@ def _corrupt_exit(path: Path, exc: Exception) -> None:
         err=True,
     )
     raise typer.Exit(code=1)
-
-
-def load_engine(path: Path) -> PrototypeEngine:
-    """Load a :class:`PrototypeEngine` from ``path``."""
-    from .utils import load_engine as _loader
-
-    return _loader(path)
 
 
 # --- Engine Commands ---

--- a/compact_memory/utils.py
+++ b/compact_memory/utils.py
@@ -1,48 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, List
-
-
-from .embedding_pipeline import get_embedding_dim
-from .vector_store import InMemoryVectorStore
 
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .prototype_engine import PrototypeEngine
-
-
-def load_engine(path: Path) -> "PrototypeEngine":
-    """Load a :class:`PrototypeEngine` from ``path``."""
-
-    from .prototype_engine import PrototypeEngine
-    from .models import BeliefPrototype, RawMemory
-    import json
-    import numpy as np
-
-    manifest_file = path / "engine_manifest.json"
-    memories_file = path / "memories.json"
-    vectors_file = path / "vectors.npy"
-
-    with open(manifest_file, "r", encoding="utf-8") as fh:
-        manifest = json.load(fh)
-
-    meta = manifest.get("meta", {})
-    dim = meta.get("embedding_dim", get_embedding_dim())
-    normalized = meta.get("normalized", True)
-    store = InMemoryVectorStore(embedding_dim=dim, normalized=normalized)
-    store.meta = meta
-    store.prototypes = [BeliefPrototype(**p) for p in manifest.get("prototypes", [])]
-    store.proto_vectors = np.load(vectors_file)
-
-    with open(memories_file, "r", encoding="utf-8") as fh:
-        store.memories = [RawMemory(**m) for m in json.load(fh)]
-
-    store.index = {p.prototype_id: i for i, p in enumerate(store.prototypes)}
-    store._index_dirty = True
-
-    engine = PrototypeEngine(store)
-    return engine
 
 
 def format_ingest_results(
@@ -65,4 +27,4 @@ def format_ingest_results(
     return lines
 
 
-__all__ = ["load_engine", "format_ingest_results"]
+__all__ = ["format_ingest_results"]

--- a/tests/test_cli_ingest_query.py
+++ b/tests/test_cli_ingest_query.py
@@ -28,6 +28,6 @@ def test_query_returns_reply(tmp_path: Path, monkeypatch):
     store = InMemoryVectorStore(embedding_dim=dim)
     agent = PrototypeEngine(store)
     agent.add_memory("the sky is blue")
-    monkeypatch.setattr("compact_memory.cli.load_engine", lambda path: agent)
+    monkeypatch.setattr("compact_memory.engines.load_engine", lambda path: agent)
     result = runner.invoke(app, ["query", "sky?"], env=_env(tmp_path))
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- delete old `load_engine` helper
- use `compact_memory.engines.load_engine` in CLI
- update unit test to patch the new loader

## Testing
- `pre-commit run --files compact_memory/utils.py compact_memory/cli.py tests/test_cli_ingest_query.py tests/test_base_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e50bf7408329b4eeffad8d2e278d