### PR TITLE
Fix documentation for compress command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ Shared engines can be distributed as standard Python packages (e.g., via PyPI) o
     ```
     Once installed in your Python environment, Compact Memory's plugin loader will automatically discover the engine if it correctly uses the entry point system.
 
-*   **Installation (Directory Packages):** For engines distributed as a directory, you can place them in a location scanned by Compact Memory. (Refer to `docs/SHARING_ENGINES.md` for details on plugin paths like `$COMPACT_MEMORY_PLUGINS_PATH`).
+*   **Installation (Directory Packages):** For engines distributed as a directory, you can place them in a location scanned by Compact Memory. (Refer to `docs/SHARING_ENGINES.md` for details on plugin paths like `$COMPACT_MEMORY_ENGINES_PATH`).
 
 *   **Using a Shared Engine:** Once installed and discovered, you can use a shared engine like any built-in engine by specifying its `engine_id` in the CLI or Python API:
     ```bash
     compact-memory compress --text "my text" --engine community_engine_id --budget 100
     ```
     ```python
-    from BaseCompressionEngine.core import get_compression_engine
+    from compact_memory import get_compression_engine
     engine = get_compression_engine("community_engine_id")()
     # ... use the engine
     ```
@@ -171,7 +171,7 @@ For contributors or those looking to build custom solutions on top of Compact Me
 
 ## Features
 
-- Command-line interface for memory container management (`memory init`, `memory stats`, `memory validate`, `memory clear`), data processing (`ingest`, `query`, `compress`), configuration (`config set`, `config show`), and developer tools (`dev list-engines`, `dev evaluate-compression`, etc.).
+- Command-line interface for memory container management (`memory init`, `memory stats`, `memory validate`, `memory clear`), data processing (`query`, `compress`), configuration (`config set`, `config show`), and developer tools (`dev list-engines`, `dev evaluate-compression`, etc.).
 - Global configuration options settable via CLI, environment variables, or config files.
 - Pluggable memory compression engines.
  - Pluggable CompressionEngines.
@@ -313,7 +313,7 @@ You can also set a default location for the on-disk memory store and other globa
 ## Configuration
 
 Compact Memory uses a hierarchical configuration system:
-1.  **Command-line arguments:** Highest precedence (e.g., `compact-memory --memory-path ./my_memory ingest ...`).
+1.  **Command-line arguments:** Highest precedence (e.g., `compact-memory --memory-path ./my_memory compress --file data.txt --engine prototype --budget 100`).
 2.  **Environment variables:** (e.g., `COMPACT_MEMORY_PATH`, `COMPACT_MEMORY_DEFAULT_MODEL_ID`, `COMPACT_MEMORY_DEFAULT_ENGINE_ID`).
 3.  **Local project config:** `.gmconfig.yaml` in the current directory.
 4.  **User global config:** `~/.config/compact_memory/config.yaml`.
@@ -336,7 +336,7 @@ export COMPACT_MEMORY_PATH=~/my_compact_memories
 
 ## Quick Start / Core Workflow
 
-The `compact-memory` Command-Line Interface (CLI) is your primary tool for managing memory containers, ingesting data, querying, and summarizing.
+The `compact-memory` Command-Line Interface (CLI) is your primary tool for managing memory containers, compressing data, querying, and summarizing.
 
 **1. Initialize a Memory Container:**
 First, create a new memory container. This directory will store the container's data.
@@ -352,21 +352,21 @@ To avoid specifying `--memory-path ./my_memory` for every command that interacts
     ```bash
     compact-memory config set compact_memory_path ./my_memory
     ```
-    Now, `compact-memory` commands like `ingest` and `query` will default to using `./my_memory`.
+    Now, `compact-memory` commands like `compress` and `query` will default to using `./my_memory`.
 *   **Set for current session (environment variable):**
     ```bash
     export COMPACT_MEMORY_PATH=$(pwd)/my_memory
     ```
 
-**3. Ingest Data:**
-Add information to the memory container.
+**3. Compress Data into the Container:**
+Add information by compressing files directly into the memory store.
 ```bash
 # If compact_memory_path is set (globally or via env var):
-compact-memory ingest path/to/your_document.txt
-compact-memory ingest path/to/your_data_directory/
+compact-memory compress --file path/to/your_document.txt --engine prototype --budget 200
+compact-memory compress --dir path/to/your_data_directory/ --engine prototype --budget 200
 
 # Or, specify the memory path directly for a specific command:
-compact-memory --memory-path ./my_memory ingest path/to/your_document.txt
+compact-memory compress --memory-path ./my_memory --file path/to/your_document.txt --engine prototype --budget 200
 ```
 
 **4. Query the Container:**

--- a/docs/ENGINE_DEVELOPMENT.md
+++ b/docs/ENGINE_DEVELOPMENT.md
@@ -6,14 +6,13 @@ This guide provides a comprehensive walkthrough for researchers and developers l
 
 At the heart of Compact Memory's extensibility is the `BaseCompressionEngine` abstract base class. Any new engine you develop must inherit from this class and implement its required methods.
 
-### Abstract Base Class: `BaseCompressionEngine.core.engines_abc.BaseCompressionEngine`
+### Abstract Base Class: `compact_memory.engines.BaseCompressionEngine`
 
 ```python
 from abc import ABC, abstractmethod
 from typing import Union, List, Tuple, Any, Optional, Dict
 
-from BaseCompressionEngine.core.trace import CompressionTrace
-from BaseCompressionEngine.core.engines_abc import CompressedMemory
+from compact_memory.engines import CompressionTrace, CompressedMemory
 
 class BaseCompressionEngine(ABC):
     # Unique identifier for your engine. This is crucial for registration and selection.
@@ -96,8 +95,7 @@ Your primary task is to implement the `compress` method. Here's what to consider
 ### Example: A Simple Truncation Engine
 
 ```python
-from BaseCompressionEngine.core.engines_abc import BaseCompressionEngine, CompressedMemory
-from BaseCompressionEngine.core.trace import CompressionTrace
+from compact_memory.engines import BaseCompressionEngine, CompressedMemory, CompressionTrace
 from compact_memory.token_utils import get_tokenizer, token_count
 
 class SimpleTruncateEngine(BaseCompressionEngine):

--- a/docs/RUNNING_EXPERIMENTS.md
+++ b/docs/RUNNING_EXPERIMENTS.md
@@ -17,7 +17,7 @@ cfg = ResponseExperimentConfig(
 ```
 
 During the run each metric is instantiated and its scores averaged across the
-Beyond task-specific accuracy, experiments should ideally capture efficiency metrics. The `CompressionTrace` object (see `BaseCompressionEngine/core/trace.py`) is designed to hold such details. Key metrics include:
+Beyond task-specific accuracy, experiments should ideally capture efficiency metrics. The `CompressionTrace` object (see `compact_memory/engines/__init__.py`) is designed to hold such details. Key metrics include:
     * Final compressed prompt token count.
     * Original uncompressed token count.
     * Processing time of the compression engine.

--- a/docs/SHARING_ENGINES.md
+++ b/docs/SHARING_ENGINES.md
@@ -23,7 +23,7 @@ Compact Memory discovers available compression engines through two primary mecha
 2.  **Local Plugin Directories:**
     *   For development, testing, or simpler distribution without creating a full Python package, Compact Memory can load engines from specific local directories.
     *   These directories must contain valid "engine packages" (see below).
-    *   Compact Memory checks the path specified by the `COMPACT_MEMORY_PLUGINS_PATH` environment variable. This variable can contain multiple paths, separated by the OS's standard path separator (e.g., `:` for Linux/macOS, `;` for Windows).
+*   Compact Memory checks the path specified by the `COMPACT_MEMORY_ENGINES_PATH` environment variable. This variable can contain multiple paths, separated by the OS's standard path separator (e.g., `:` for Linux/macOS, `;` for Windows).
     *   It also checks a default user-specific plugin directory (e.g., `~/.local/share/compact_memory/plugins` on Linux, or similar paths on other OSes, determined by the `platformdirs` library).
     *   Engines found in these directories are registered. If multiple engines with the same ID are found, a precedence order applies (typically, local directory plugins might override entry point plugins, and built-in engines have the highest precedence unless overridden by a plugin specifically designed to do so). Use `compact-memory dev list-engines` to see which engine is active and its source.
 
@@ -150,7 +150,7 @@ This will check for required files, fields in the manifest, and basic loadabilit
         ```
     *   **Python API:**
         ```python
-        from BaseCompressionEngine.core import get_compression_engine
+        from compact_memory import get_compression_engine
 
         engine_instance = get_compression_engine("<shared_engine_id>")()
         compressed_mem, trace = engine_instance.compress(text, budget)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,7 +51,7 @@ Assistant:
 You can also call compression engines programmatically:
 
 ```python
-from BaseCompressionEngine.core import get_compression_engine
+from compact_memory import get_compression_engine
 from compact_memory.token_utils import get_tokenizer
 
 engine = get_compression_engine("first_last")()

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -3,14 +3,14 @@ This section provides a reference for the core public APIs of Compact Memory, pa
 > **Note:** The content below is a manually curated list of key components. A full, auto-generated API reference (e.g., via Sphinx) is recommended for complete details and is planned for future updates.
 ## Core Engine Development APIs
 The following classes and modules are fundamental when developing new compression engines.
-### `BaseCompressionEngine.core.engines_abc.BaseCompressionEngine`
+### `compact_memory.engines.BaseCompressionEngine`
 The abstract base class for all compression engines. Developers must subclass this to create new engines.
 *   `Key methods: \`compress(self, text_or_chunks, llm_token_budget, **kwargs)\``
 *   `Key attributes: \`id\` (string identifier for the engine)`
-### `BaseCompressionEngine.core.engines_abc.CompressedMemory`
+### `compact_memory.engines.CompressedMemory`
 A data class that holds the output of a compression operation.
 *   `Key attributes: \`text\` (string, the compressed content), \`metadata\` (optional dictionary)`
-### `BaseCompressionEngine.core.trace.CompressionTrace`
+### `compact_memory.engines.CompressionTrace`
 A data class used to record the steps and metadata of a compression process. Essential for debugging and explainability.
 *   `Key attributes: \`engine_name\`, \`engine_params\`, \`input_summary\`, \`steps\` (list of dicts), \`output_summary\`, \`processing_ms\`, \`final_compressed_object_preview\``
 ## Core Validation APIs

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -33,18 +33,6 @@ You can manage your global configuration using the `compact-memory config` comma
 
 These are the primary commands for interacting with Compact Memory.
 
-### `compact-memory ingest`
-
-Ingests a text file or files in a directory into an engine store. The engine store is determined by the active `--memory-path` or its configured default.
-
-**Usage:** `compact-memory ingest [OPTIONS] SOURCE`
-
-**Arguments:**
-*   `SOURCE`: Path to the text file or directory containing text files to ingest. (Required)
-
-**Options:**
-*   `--tau FLOAT`: Similarity threshold (0.5-0.95) for memory consolidation. Overrides the engine store's existing tau if set. If the store is new, this tau is used for initialization.
-*   `--json`: Output ingestion summary statistics in JSON format.
 
 ### `compact-memory query`
 

--- a/docs/tutorials/01_integrating_into_pipelines.md
+++ b/docs/tutorials/01_integrating_into_pipelines.md
@@ -23,11 +23,8 @@ This tutorial demonstrates how to programmatically use an existing compression e
 First, let\'s import the required components from Compact Memory and any other libraries.
 
 ```python
-from BaseCompressionEngine.core import (
-    get_compression_engine,
-    CompressedMemory,
-    BaseCompressionEngine,
-)
+from compact_memory import get_compression_engine
+from compact_memory.engines import CompressedMemory, BaseCompressionEngine
 from compact_memory.token_utils import get_tokenizer, token_count # For token counting
 import os # For API keys, if needed
 
@@ -169,11 +166,8 @@ print(llm_response)
 ## Complete Example Script
 
 ```python
-from BaseCompressionEngine.core import (
-    get_compression_engine,
-    CompressedMemory,
-    BaseCompressionEngine,
-)
+from compact_memory import get_compression_engine
+from compact_memory.engines import CompressedMemory, BaseCompressionEngine
 from compact_memory.token_utils import get_tokenizer, token_count
 import os
 

--- a/docs/tutorials/02_building_a_simple_engine.md
+++ b/docs/tutorials/02_building_a_simple_engine.md
@@ -16,8 +16,7 @@ Our engine, \`FirstNSentencesEngine\`, will:
 Create a Python file for your engine, for example, \`my_engines.py\`.
 ```python
 from typing import Union, List, Tuple, Any
-from BaseCompressionEngine.core.engines_abc import BaseCompressionEngine, CompressedMemory
-from BaseCompressionEngine.core.trace import CompressionTrace
+from compact_memory.engines import BaseCompressionEngine, CompressedMemory, CompressionTrace
 from compact_memory.token_utils import get_tokenizer, token_count
 
 try:
@@ -146,7 +145,7 @@ compact-memory compress --text "Your long text here..." --engine first_n_sentenc
 ```
 *   Python API:
 ```python
-from BaseCompressionEngine.core import get_compression_engine
+from compact_memory import get_compression_engine
 # Assuming FirstNSentencesEngine is registered or imported
 # For example, if you ran the __main__ block from my_engines.py or imported it.
 

--- a/docs/tutorials/03_packaging_an_engine.md
+++ b/docs/tutorials/03_packaging_an_engine.md
@@ -26,8 +26,7 @@ compact_memory_my_engine/
 Now, replace the contents of the template \`compact_memory_my_engine/engine.py\` with your actual engine code from \`my_awesome_engine.py\`.
 Let's assume your \`my_awesome_engine.py\` looked something like this:
 ```python
-from BaseCompressionEngine.core.engines_abc import BaseCompressionEngine, CompressedMemory
-from BaseCompressionEngine.core.trace import CompressionTrace
+from compact_memory.engines import BaseCompressionEngine, CompressedMemory, CompressionTrace
 # ... any other imports your engine needs ...
 
 class MyAwesomeEngine(BaseCompressionEngine):
@@ -109,7 +108,7 @@ compact-memory dev list-engines # Your engine should appear here
 compact-memory compress --file input.txt --engine awesome_strat --budget 100 --engine-params '{"custom_param": 10}'
 ```
 ```python
-from BaseCompressionEngine.core import get_compression_engine
+from compact_memory import get_compression_engine
 MyEngineClass = get_compression_engine("awesome_strat")
 my_strat_instance = MyEngineClass(custom_param=10)
 # ... use my_strat_instance.compress(...) ...


### PR DESCRIPTION
## Summary
- drop outdated ingest section from CLI docs
- switch README quickstart to `compress --memory-path`
- update plugin path variable to `COMPACT_MEMORY_ENGINES_PATH`
- replace old import paths with `compact_memory.engines`

## Testing
- `pre-commit run --files README.md docs/ENGINE_DEVELOPMENT.md docs/RUNNING_EXPERIMENTS.md docs/SHARING_ENGINES.md docs/USAGE.md docs/api_reference.md docs/cli_reference.md docs/tutorials/01_integrating_into_pipelines.md docs/tutorials/02_building_a_simple_engine.md docs/tutorials/03_packaging_an_engine.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841e730876c8329b225de072b6627ef