### PR TITLE
Fix prototype engine save and load

### DIFF
--- a/compact_memory/prototype_engine.py
+++ b/compact_memory/prototype_engine.py
@@ -758,12 +758,18 @@ class PrototypeEngine(BaseCompressionEngine):
         import json
 
         path = Path(path)
-        super().save(path)
         path.mkdir(parents=True, exist_ok=True)
-        manifest = {
-            "meta": self.store.meta,
-            "prototypes": [p.model_dump(mode="json") for p in self.store.prototypes],
-        }
+        super().save(path)
+        with open(path / "engine_manifest.json", "r", encoding="utf-8") as fh:
+            manifest = json.load(fh)
+        manifest.update(
+            {
+                "meta": self.store.meta,
+                "prototypes": [
+                    p.model_dump(mode="json") for p in self.store.prototypes
+                ],
+            }
+        )
         with open(path / "engine_manifest.json", "w", encoding="utf-8") as fh:
             json.dump(manifest, fh)
         with open(path / "memories.json", "w", encoding="utf-8") as fh:

--- a/tests/test_prototype_engine.py
+++ b/tests/test_prototype_engine.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from compact_memory.prototype_engine import PrototypeEngine
 from compact_memory.vector_store import InMemoryVectorStore
 from compact_memory.embedding_pipeline import get_embedding_dim
+from compact_memory.engines import load_engine
 
 
 def test_engine_save_load(tmp_path: Path, patch_embedding_model) -> None:
@@ -22,3 +23,16 @@ def test_engine_save_load(tmp_path: Path, patch_embedding_model) -> None:
     assert (dest / "vectors.npy").exists()
     assert (dest / "entries.json").exists()
     assert (dest / "embeddings.npy").exists()
+
+
+def test_load_engine(tmp_path: Path, patch_embedding_model) -> None:
+    dim = get_embedding_dim()
+    store = InMemoryVectorStore(embedding_dim=dim)
+    engine = PrototypeEngine(store)
+    engine.add_memory("lorem ipsum dolor")
+    dest = tmp_path / "engine"
+    engine.save(dest)
+
+    loaded = load_engine(dest)
+    res = loaded.query("lorem", top_k_prototypes=1, top_k_memories=1)
+    assert res["memories"]


### PR DESCRIPTION
## Summary
- preserve `engine_id` and `engine_class` when saving `PrototypeEngine`
- create an in-memory vector store when loading a saved `PrototypeEngine`
- add regression test for loading with `load_engine`

## Testing
- `pre-commit run --files compact_memory/prototype_engine.py compact_memory/engines/__init__.py tests/test_prototype_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f41eb08c83298ac686494bf033ac