### PR TITLE
Rename inspect-strategy command

### DIFF
--- a/compact_memory/cli.py
+++ b/compact_memory/cli.py
@@ -1056,10 +1056,10 @@ def list_registered_engines(
 
 
 @dev_app.command(
-    "inspect-strategy",
+    "inspect-engine",
     help="Inspects aspects of a compression engine, currently focused on 'prototype' engine's beliefs.",
 )
-def inspect_strategy(
+def inspect_engine(
     engine_name: str = typer.Argument(
         ...,
         help="The name of the engine to inspect. Currently, only 'prototype' is supported.",

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -165,9 +165,9 @@ Lists all available compression engine IDs, their versions, and sources (built-i
 
 #### `compact-memory dev inspect-engine`
 Inspects aspects of a compression engine, currently focused on 'prototype' engine's beliefs.
-**Usage:** `compact-memory dev inspect-engine [OPTIONS] STRATEGY_NAME`
+**Usage:** `compact-memory dev inspect-engine [OPTIONS] ENGINE_NAME`
 **Arguments:**
-*   `STRATEGY_NAME`: The name of the engine to inspect. Currently, only 'prototype' is supported. (Required)
+*   `ENGINE_NAME`: The name of the engine to inspect. Currently, only 'prototype' is supported. (Required)
 **Options:**
 *   `--memory-path TEXT`: Path to the engine store directory. Overrides global setting if provided. Required if '--list-prototypes' is used.
 *   `--list-prototypes`: List consolidated prototypes (beliefs) if the engine is 'prototype' and a memory path is provided.


### PR DESCRIPTION
## Summary
- rename `inspect-strategy` typer command to `inspect-engine`
- update CLI documentation accordingly

## Testing
- `pre-commit run --files compact_memory/cli.py docs/cli_reference.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841f4202b6c8329bc5e6a66400fcdad