### PR TITLE
Fix engine import cycle

### DIFF
--- a/compact_memory/engines/active_memory_engine.py
+++ b/compact_memory/engines/active_memory_engine.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import List, Optional, Any, Dict, Union, Tuple
 
 import numpy as np
-from . import BaseCompressionEngine, CompressedMemory, CompressionTrace
+
+# Import base classes directly to avoid package import side effects
+from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
 from ..active_memory_manager import ActiveMemoryManager, ConversationTurn
 from compact_memory.prompt_budget import PromptBudget
 from compact_memory.embedding_pipeline import embed_text

--- a/compact_memory/engines/first_last_engine.py
+++ b/compact_memory/engines/first_last_engine.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import List, Union, Any
 
-from . import BaseCompressionEngine, CompressedMemory, CompressionTrace
+# Import directly from base to avoid package import side effects
+from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
 from .registry import register_compression_engine
 
 

--- a/compact_memory/engines/no_compression_engine.py
+++ b/compact_memory/engines/no_compression_engine.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Any, List
 
 from compact_memory.token_utils import truncate_text
-from . import BaseCompressionEngine, CompressedMemory, CompressionTrace
+
+# Import directly from base to avoid triggering package-level side effects
+from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
 
 try:  # pragma: no cover - optional dependency
     import tiktoken

--- a/compact_memory/engines/pipeline_engine.py
+++ b/compact_memory/engines/pipeline_engine.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Union, Any
 
-from . import BaseCompressionEngine, CompressedMemory, CompressionTrace
+# Import base classes directly to avoid package-level registration
+from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
 from .registry import get_compression_engine
 
 


### PR DESCRIPTION
## Summary
- avoid importing __init__ when loading built-in engines
- update engine modules to import directly from `base`

## Testing
- `pre-commit run --files compact_memory/engines/active_memory_engine.py compact_memory/engines/first_last_engine.py compact_memory/engines/no_compression_engine.py compact_memory/engines/pipeline_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422fe0c4dc8329aff94786e65dd476