### PR TITLE
Input:

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 # Install the project and its dependencies as declared in pyproject.toml
 if [ -f pyproject.toml ]; then
     # Editable install so source changes are picked up without reinstalling
+    pip3 install --upgrade setuptools
     pip3 install -e . --no-build-isolation
 fi
 


### PR DESCRIPTION
Fix BackendUnavailable error by upgrading setuptools

The setup script was failing with a `pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'` error. This was because setuptools was not being explicitly installed or upgraded.

This commit fixes the error by adding `pip3 install --upgrade setuptools` to the `.codex/setup.sh` script before the project dependencies are installed.

Output:
I've fixed the `BackendUnavailable` error by ensuring `setuptools` is upgraded.

The setup script was encountering an issue: `pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'`. This happened because `setuptools` wasn't being explicitly installed or upgraded.

To resolve this, I've modified your `.codex/setup.sh` script to include `pip3 install --upgrade setuptools` before the project dependencies are installed.