### PR TITLE
Restore AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Compact Memory Agent Guidelines
+
+These instructions guide Codex when modifying this repository.
+
+This project is currently pre-release. Backward compatibility is not
+a concern and APIs may change freely.
+
+## Scope
+All directories in this repository follow these rules.
+
+### Prototype utilities
+Experimental engines may include helper modules alongside the code that
+implements them. Keep each engine self‑contained — avoid shared
+``prototype_utils`` or other common packages across experimental engines.
+If needed, these engines will eventually live in their own repositories.
+
+Tests for these experimental modules should reside next to the code rather than
+in the top‑level ``tests`` package. This keeps each engine self‑contained and
+portable.
+
+## Coding Standards
+- Format Python code with **Black** and lint with **Flake8**. Run `pre-commit run --files <files>` before committing.
+- Follow **PEP 8** and include type hints for functions and methods.
+- Write clear docstrings in the Google style.
+
+## Testing
+- Run `pytest` from the repository root after making code changes.
+- If tests fail due to missing dependencies in the environment, mention this in the PR summary.
+
+## Commits
+- Use descriptive commit messages in the imperative mood (e.g., "fix: handle bad input").
+- Group related changes and keep commits focused.
+
+## Pull Requests
+- Rebase on the latest `main` before creating a patch.
+- Summarize the purpose of the PR and note any limitations encountered during testing.
+
+## LLM Integration
+The `local_llm.py` module and `llm_providers` package are essential for Colab examples. Do not remove them when cleaning up the codebase.

--- a/examples/sample_engine_package/README.md
+++ b/examples/sample_engine_package/README.md
@@ -58,7 +58,7 @@ Compact Memory can discover engines packaged in this format if they are placed i
 
 For local development and testing, you can often make your engine available by ensuring the directory containing your package is in your `PYTHONPATH`, or by using local installation options if provided by Compact Memory's CLI or main setup.
 
-Refer to the main Compact Memory documentation on "Sharing Strategies" ([`docs/SHARING_STRATEGIES.md`](../../docs/SHARING_STRATEGIES.md)) and "Developing Compression Strategies" ([`docs/ENGINE_DEVELOPMENT.md`](../../docs/ENGINE_DEVELOPMENT.md)) for more details on how engines are loaded and best practices for development.
+Refer to the main Compact Memory documentation on "Sharing Engines" ([`docs/SHARING_ENGINES.md`](../../docs/SHARING_ENGINES.md)) and "Developing Compression Engines" ([`docs/ENGINE_DEVELOPMENT.md`](../../docs/ENGINE_DEVELOPMENT.md)) for more details on how engines are loaded and best practices for development.
 
 ## Key Components Explained
 


### PR DESCRIPTION
## Summary
- restore `AGENTS.md` that was removed in a recent refactor
- update terminology to use "engine" instead of "strategy"

## Testing
- `pre-commit run --files AGENTS.md examples/sample_engine_package/README.md` *(fails: pre-commit not installed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843012d4b9883299e44f435cc68a32b