### PR TITLE
Fix missing platformdirs dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 
 ## Enhancements
 - Terminology standardized: documentation and CLI now consistently refer to compression engines, replacing the leftover “CompressionStrategies” term.
+- Added `platformdirs` as a required dependency to ensure plugin discovery works across operating systems.
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ This project requires **Python 3.11+**.
    ```bash
    pip install -r requirements.txt
    ```
+   The CLI also relies on the `platformdirs` package for determining
+   user-specific plugin paths. It is included in the project's
+   dependencies but can be installed manually if needed:
+   ```bash
+   pip install platformdirs
+   ```
    Optional features such as spaCy sentence segmentation or local models
    require extra dependencies. Install them with pip extras, e.g.:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "typer>=0.16.0",
     "portalocker",
     "rich>=13.6",
+    "platformdirs",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add `platformdirs` to `pyproject.toml` dependencies
- document the requirement in the README
- note the change in the changelog

## Testing
- `pre-commit run --files pyproject.toml CHANGELOG.md README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684354f7dd24832991044d143357ab31