### PR TITLE
Improve missing dependency guidance

### DIFF
--- a/src/compact_memory/embedding_pipeline.py
+++ b/src/compact_memory/embedding_pipeline.py
@@ -65,7 +65,8 @@ def _load_model(model_name: str, device: str) -> SentenceTransformer:
             SentenceTransformer = _ST
         except Exception as exc:  # pragma: no cover - optional dependency
             raise ImportError(
-                "sentence-transformers is required for embedding"
+                "sentence-transformers is required for embedding. "
+                "Install with 'pip install \"compact-memory[embedding]\"'."
             ) from exc
     if torch is None:
         try:


### PR DESCRIPTION
## Summary
- clarify error message when `sentence-transformers` isn't installed

## Testing
- `pre-commit run --files src/compact_memory/embedding_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684359b990e8832980a63536e2d0a6ea