### PR TITLE
feat: Integrate LLM configuration into CLI

### DIFF
--- a/docs/COMPRESSION_ENGINES.md
+++ b/docs/COMPRESSION_ENGINES.md
@@ -15,6 +15,8 @@ In the context of LLMs and memory systems, "compression" refers to techniques th
 
 Compression is not necessarily about achieving the highest possible data compression ratio in a traditional sense (like Gzip). Instead, it's about "semantic compression" or "information distillation."
 
+**Note on LLM-Dependent Engines:** Some advanced compression engines, particularly those performing abstractive summarization or complex transformations (e.g., a future `readagent_gist` engine), may require a Large Language Model (LLM) to function. Configuring these LLMs (selecting the provider, model, API keys, etc.) is crucial for such engines. For details on how to configure LLMs when using these engines via the CLI, please refer to the `compact-memory compress --help` output, the [CLI Reference](./cli_reference.md), and the [Configuration Guide](./configuration.md#llm-model-configurations-llm_models_configyaml).
+
 ## 2. Types of Compression Engines/Strategies
 
 ### a. Extractive Summarization (Truncation-based)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,4 +116,55 @@ You can set default values for key options to avoid typing them repeatedly. Thes
     ```
 
 By effectively using the configuration layers, especially `compact-memory config set` for your global defaults, you can significantly simplify your interactions with the Compact Memory CLI. Remember that command-line options always override these defaults if you need to work with a different agent or setting temporarily.
+
+## LLM Model Configurations (`llm_models_config.yaml`)
+
+For more complex LLM configurations, especially when using multiple LLMs or different settings for various tasks, you can create an `llm_models_config.yaml` file. By default, Compact Memory looks for this file in the current working directory (your project's root).
+
+This file allows you to define named configurations for different LLM providers and models. You can then refer to these configurations using the `--llm-config NAME` option in commands like `compact-memory compress` or `compact-memory engine init`.
+
+**Example `llm_models_config.yaml`:**
+
+```yaml
+# llm_models_config.yaml example
+
+my-local-summarizer:
+  provider: local
+  # model_path: /path/to/your/models/mistral-7b-instruct  # If your local provider uses model_path
+  model_name: mistralai/Mistral-7B-Instruct-v0.1 # Or a Hugging Face model name
+  # Other parameters specific to the local provider can be added here.
+
+my-openai-gpt4:
+  provider: openai
+  model_name: gpt-4-turbo
+  # api_key: sk-YOUR_OPENAI_KEY_HERE # Optional: can be stored here or in env variables.
+  # max_tokens: 8000 # Example of a parameter an engine might use if passed this config.
+
+my-openai-gpt3-5:
+  provider: openai
+  model_name: gpt-3.5-turbo
+
+another-mock-config:
+  provider: mock
+  # Mock provider usually doesn't need more config, but you could add custom fields if your mock was extended.
+
+# Configuration for a Gemini model
+my-gemini-pro:
+  provider: gemini
+  model_name: gemini-pro
+  # api_key: YOUR_GOOGLE_API_KEY # Optional, can use GOOGLE_API_KEY env var
+```
+
+**Key Fields:**
+
+*   **`provider`**: (Mandatory) Specifies the type of LLM provider. Examples: `local`, `openai`, `gemini`, `mock`.
+*   **`model_name`**: The identifier for the model used by the provider (e.g., `gpt-4-turbo` for OpenAI, `mistralai/Mistral-7B-Instruct-v0.1` for a Hugging Face model used with `local` provider).
+*   **`model_path`**: Some local providers might use this to specify the direct path to model files. (Usage depends on the specific local provider's implementation).
+*   **`api_key`**: API key for remote services like OpenAI or Gemini.
+    *   **Security Note:** Storing API keys in plaintext YAML is convenient for personal use but is generally discouraged for security reasons, especially if the file is shared or version-controlled. It's often safer to use environment variables (e.g., `OPENAI_API_KEY`, `GOOGLE_API_KEY`) which the providers typically read automatically.
+*   Other fields (like `max_tokens` in the example) can be added. These are not directly used by the LLM provider factory itself but can be part of the configuration dictionary passed to an engine if the engine is designed to interpret them.
+
+When you use the `--llm-config NAME` CLI flag (e.g., `compact-memory compress ... --llm-config my-local-summarizer`), Compact Memory will load the settings from the corresponding block in `llm_models_config.yaml`.
+
+This system allows you to manage multiple LLM setups cleanly and switch between them easily for different operations or projects.
 ```

--- a/src/compact_memory/llm_providers/__init__.py
+++ b/src/compact_memory/llm_providers/__init__.py
@@ -6,10 +6,12 @@ break basic functionality or tests that don't require them.
 
 from .openai_provider import OpenAIProvider
 from .mock_provider import MockLLMProvider # Added MockLLMProvider
+from .factory import create_llm_provider     # Add this line
 
 __all__ = [
     "OpenAIProvider",
     "MockLLMProvider", # Added MockLLMProvider
+    "create_llm_provider", # Add this
 ]
 
 try:  # Gemini provider requires ``google-generativeai``

--- a/src/compact_memory/llm_providers/factory.py
+++ b/src/compact_memory/llm_providers/factory.py
@@ -1,0 +1,89 @@
+import os
+from typing import Optional, Any, Dict
+from compact_memory.config import Config
+from compact_memory.llm_providers_abc import LLMProvider
+from compact_memory.llm_providers import OpenAIProvider, MockLLMProvider
+# Optional providers will be imported within create_llm_provider with try-except
+
+def create_llm_provider(
+    config_name: Optional[str] = None,
+    provider_type: Optional[str] = None,
+    model_name: Optional[str] = None, # Primarily for context, not direct use in factory for provider instantiation
+    api_key: Optional[str] = None,
+    app_config: Optional[Config] = None,
+) -> LLMProvider:
+    """
+    Creates an LLM provider instance based on configuration name or direct parameters.
+    """
+    if not app_config:
+        app_config = Config()
+
+    llm_config_data: Optional[Dict[str, Any]] = None
+    # model_path: Optional[str] = None # Not directly used by factory for now
+
+    if config_name:
+        llm_config_data = app_config.get_llm_config(config_name)
+        if not llm_config_data:
+            available_configs = list(app_config.get_all_llm_configs().keys())
+            raise ValueError(
+                f"LLM configuration '{config_name}' not found in llm_models_config.yaml. "
+                f"Available configurations: {available_configs}"
+            )
+
+        # Values from YAML config override direct CLI flags if config_name is used
+        provider_type = llm_config_data.get("provider", provider_type)
+        api_key = llm_config_data.get("api_key", api_key)
+        # model_path = llm_config_data.get("model_path") # For future use if providers take path at init
+
+    if not provider_type:
+        # This should ideally be caught by CLI validation (e.g. if --llm-config is invalid and no --llm-provider-type)
+        raise ValueError("LLM provider type must be specified either via a valid --llm-config or --llm-provider-type.")
+
+    provider_instance: Optional[LLMProvider] = None
+    provider_type_lower = provider_type.lower()
+
+    if provider_type_lower == "openai":
+        if api_key:
+            os.environ["OPENAI_API_KEY"] = api_key # OpenAI client typically checks this env var
+        provider_instance = OpenAIProvider()
+    elif provider_type_lower == "mock":
+        provider_instance = MockLLMProvider()
+    elif provider_type_lower == "local":
+        try:
+            from compact_memory.llm_providers import LocalTransformersProvider
+            if LocalTransformersProvider is None: # Check if it was set to None in __init__.py due to import error
+                raise ImportError("LocalTransformersProvider is None, likely due to missing dependencies.")
+            provider_instance = LocalTransformersProvider()
+        except ImportError as e:
+            raise ImportError(
+                "Local LLM provider (LocalTransformersProvider) could not be imported. "
+                "Ensure 'transformers' (and 'torch') are installed (e.g., 'pip install compact-memory[local]'). "
+                f"Original error: {e}"
+            )
+    elif provider_type_lower == "gemini":
+        try:
+            from compact_memory.llm_providers import GeminiProvider
+            if GeminiProvider is None: # Check if it was set to None in __init__.py
+                raise ImportError("GeminiProvider is None, likely due to missing dependencies.")
+            if api_key: # Gemini client uses GOOGLE_API_KEY
+                os.environ["GOOGLE_API_KEY"] = api_key
+            provider_instance = GeminiProvider()
+        except ImportError as e:
+            raise ImportError(
+                "Gemini LLM provider (GeminiProvider) could not be imported. "
+                "Ensure 'google-generativeai' is installed (e.g., 'pip install compact-memory[gemini]'). "
+                f"Original error: {e}"
+            )
+    else:
+        # Consider dynamically listing available provider types from __init__.py or a registry
+        known_provider_slugs = ["openai", "local", "mock", "gemini"]
+        raise ValueError(
+            f"Unsupported LLM provider type: '{provider_type}'. "
+            f"Supported types (if dependencies are installed): {', '.join(known_provider_slugs)}."
+        )
+
+    if provider_instance is None:
+         # This path should ideally not be reached if the logic above is correct and covers all cases.
+         raise RuntimeError(f"Internal error: Could not create an LLM provider for type '{provider_type}'.")
+
+    return provider_instance

--- a/tests/test_cli_llm_compress.py
+++ b/tests/test_cli_llm_compress.py
@@ -1,0 +1,325 @@
+import os
+import shutil
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from typer.testing import CliRunner
+
+# Adjust sys.path if compact_memory is not installed in a way that tests can find it
+# import sys
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from compact_memory.main import app # Main Typer application
+from compact_memory.engines.base import BaseCompressionEngine, CompressedMemory
+from compact_memory.llm_providers_abc import LLMProvider
+from compact_memory.engines.registry import register_engine, unregister_engine, get_engine_metadata, _ENGINES
+from compact_memory.config import LLM_MODELS_CONFIG_PATH as DEFAULT_LLM_MODELS_CONFIG_PATH
+
+# --- DummyLLMEngine for Testing ---
+class DummyLLMEngine(BaseCompressionEngine):
+    id = "dummy_llm_engine"
+    requires_llm = True  # Key attribute
+
+    def __init__(self, config: Optional[dict] = None, llm_provider: Optional[LLMProvider] = None):
+        super().__init__(config=config)
+        self.llm_provider = llm_provider
+        self.engine_config = config if config else {}
+        if llm_provider is None:
+            # This check might be too strict if an engine could operate without LLM but optionally use one.
+            # For this dummy, we enforce it to test LLM provision.
+            raise ValueError("DummyLLMEngine requires an LLMProvider for this test setup.")
+
+        # Store received config for assertions in output
+        self.received_gist_model = self.engine_config.get("gist_model_name")
+        self.received_gist_length = self.engine_config.get("gist_length")
+        self.received_qa_model = self.engine_config.get("qa_model_name") # Added for completeness
+
+    def compress(self, text: str, budget: int, **kwargs) -> CompressedMemory:
+        summary = f"LLM summary of '{text[:20]}' with provider {type(self.llm_provider).__name__}."
+        if self.received_gist_model:
+            summary += f" GistModel: {self.received_gist_model}."
+        if self.received_gist_length:
+            summary += f" GistLength: {self.received_gist_length}."
+        if self.received_qa_model:
+            summary += f" QAModel: {self.received_qa_model}."
+        return CompressedMemory(text=summary, original_length=len(text), compressed_length=len(summary))
+
+# --- Test Class ---
+class TestCliLLMCompress(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+        self.test_dir = Path("test_cli_temp_data")
+        self.test_dir.mkdir(exist_ok=True)
+        self.input_file = self.test_dir / "input.txt"
+        with open(self.input_file, "w") as f:
+            f.write("This is some sample text for compression.")
+
+        # Register the dummy engine before each test
+        # Store original state of dummy_llm_engine if it somehow existed
+        self._original_dummy_engine_meta = _ENGINES.get(DummyLLMEngine.id)
+        register_engine(DummyLLMEngine)
+
+        # Handle llm_models_config.yaml
+        # We'll create it in test_dir to avoid interfering with a real one
+        self.temp_llm_config_path = self.test_dir / "llm_models_config.yaml"
+
+        # Backup and restore default llm_models_config.yaml path for test isolation
+        self.original_llm_models_config_path_in_module = None
+        if 'compact_memory.config' in sys.modules:
+            self.original_llm_models_config_path_in_module = getattr(sys.modules['compact_memory.config'], 'LLM_MODELS_CONFIG_PATH', None)
+
+        # For tests that rely on a specific llm_models_config.yaml, we'll point the module-level variable to our test one.
+        # And ensure Config instances created during the test use this path.
+        # This is done more granularly in tests needing it via @mock.patch.
+
+    def tearDown(self):
+        if self.test_dir.exists():
+            shutil.rmtree(self.test_dir)
+
+        # Unregister dummy engine and restore original state if any
+        unregister_engine(DummyLLMEngine.id)
+        if self._original_dummy_engine_meta:
+             _ENGINES[DummyLLMEngine.id] = self._original_dummy_engine_meta
+
+        if self.original_llm_models_config_path_in_module and 'compact_memory.config' in sys.modules:
+            setattr(sys.modules['compact_memory.config'], 'LLM_MODELS_CONFIG_PATH', self.original_llm_models_config_path_in_module)
+
+
+    def _create_temp_llm_config(self, content: str):
+        # This helper creates the config in the designated test temporary directory.
+        # Tests will then use mocking to make the Config class load from this path.
+        with open(self.temp_llm_config_path, "w") as f:
+            f.write(content)
+        return self.temp_llm_config_path
+
+    # --- Test Cases ---
+
+    @mock.patch('compact_memory.main.app_config') # Mocks the app_config used in ctx.obj
+    def test_compress_llm_engine_no_llm_config_error(self, mock_app_config_in_main):
+        # Test that an error occurs if an LLM-dependent engine is used without LLM config
+        # Ensure the mocked app_config returns None for default_model_id
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: None if key == "default_model_id" else default
+        mock_app_config_in_main.get_all_llm_configs.return_value = {} # No named configs available
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--budget", "50"
+            ]
+        )
+        self.assertNotEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn(f"Error: Engine '{DummyLLMEngine.id}' requires an LLM.", result.stdout)
+
+    @mock.patch('compact_memory.main.app_config') # Target the config instance the CLI command will use
+    def test_compress_with_llm_config_file(self, mock_app_config_in_main):
+        temp_config_file_path = self._create_temp_llm_config("my-test-mock: {provider: mock, model_name: mock-model-from-file}")
+
+        # Configure the mocked app_config to use this temporary file
+        # This requires that the app_config instance correctly re-initializes or its methods are individually mocked.
+        # The factory `create_llm_provider` will receive this app_config.
+        mock_app_config_in_main.get_llm_config.side_effect = lambda name: {"provider": "mock", "model_name": "mock-model-from-file"} if name == "my-test-mock" else None
+        mock_app_config_in_main.get_all_llm_configs.return_value = {"my-test-mock": {"provider": "mock"}}
+        # Ensure default_model_id is not used
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: None if key == "default_model_id" else default
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--llm-config", "my-test-mock",
+                "--budget", "50"
+            ]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("LLM summary", result.stdout)
+        self.assertIn("MockLLMProvider", result.stdout)
+        self.assertIn("GistModel: mock-model-from-file", result.stdout)
+
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_with_direct_llm_flags_mock(self, mock_app_config_in_main):
+        # Ensure default_model_id is not used
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: None if key == "default_model_id" else default
+        mock_app_config_in_main.get_all_llm_configs.return_value = {}
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--llm-provider-type", "mock",
+                "--llm-model-name", "some-mock-model",
+                "--budget", "50"
+            ]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("LLM summary", result.stdout)
+        self.assertIn("MockLLMProvider", result.stdout)
+        self.assertIn("GistModel: some-mock-model", result.stdout)
+
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_mutual_exclusion_llm_config_and_provider_type(self, mock_app_config_in_main):
+        # No need to create temp llm config file if we are just testing CLI flag validation
+        mock_app_config_in_main.get_llm_config.return_value = {"provider": "mock"} # Simulate config exists
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--llm-config", "my-test-mock", # This implies a config file entry
+                "--llm-provider-type", "mock",   # This is the conflicting direct flag
+                "--llm-model-name", "any-model",
+                "--budget", "50"
+            ]
+        )
+        self.assertNotEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("Error: --llm-config cannot be used with --llm-provider-type", result.stdout)
+
+    def test_compress_missing_model_name_with_provider_type(self):
+        # This test doesn't need app_config mocking as it's pure CLI validation
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--llm-provider-type", "mock", # Missing --llm-model-name
+                "--budget", "50"
+            ]
+        )
+        self.assertNotEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("Error: --llm-model-name must be provided if --llm-provider-type is specified", result.stdout)
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_readagent_flags_override(self, mock_app_config_in_main):
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: None if key == "default_model_id" else default
+        mock_app_config_in_main.get_all_llm_configs.return_value = {}
+
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--llm-provider-type", "mock",
+                "--llm-model-name", "default_mock_model",
+                "--readagent-gist-model-name", "override_gist_model",
+                "--readagent-gist-length", "123",
+                "--readagent-qa-model-name", "override_qa_model",
+                "--budget", "50"
+            ]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("LLM summary", result.stdout)
+        self.assertIn("MockLLMProvider", result.stdout)
+        self.assertIn("GistModel: override_gist_model", result.stdout)
+        self.assertIn("GistLength: 123", result.stdout)
+        self.assertIn("QAModel: override_qa_model", result.stdout)
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_readagent_flags_default_from_llm_model_name(self, mock_app_config_in_main):
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: None if key == "default_model_id" else default
+        mock_app_config_in_main.get_all_llm_configs.return_value = {}
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--llm-provider-type", "mock",
+                "--llm-model-name", "this_is_my_main_model",
+                "--readagent-gist-length", "99",
+                "--budget", "50"
+            ]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("LLM summary", result.stdout)
+        self.assertIn("MockLLMProvider", result.stdout)
+        self.assertIn("GistModel: this_is_my_main_model", result.stdout)
+        self.assertIn("GistLength: 99", result.stdout)
+        self.assertIn("QAModel: this_is_my_main_model", result.stdout)
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_fallback_to_default_model_id_as_provider_model(self, mock_app_config_in_main):
+        # Simulate Config.get('default_model_id') returning "mock/my-default-mock-model"
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: "mock/my-default-mock-model" if key == "default_model_id" else default
+        mock_app_config_in_main.get_llm_config.return_value = None # No named config for this one
+        mock_app_config_in_main.get_all_llm_configs.return_value = {}
+
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--budget", "50"
+            ]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("No LLM specified directly; using default from config: mock/my-default-mock-model", result.stdout)
+        self.assertIn("MockLLMProvider", result.stdout)
+        self.assertIn("GistModel: my-default-mock-model", result.stdout) # Check model from provider/model string
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_fallback_to_default_model_id_as_named_config(self, mock_app_config_in_main):
+        temp_config_file_path = self._create_temp_llm_config("default-llm-name: {provider: mock, model_name: 'mock-from-named-default'}")
+
+        # Configure the mock app_config to use this temporary file's content when queried
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: "default-llm-name" if key == "default_model_id" else default
+
+        def get_llm_config_side_effect(name):
+            if name == "default-llm-name":
+                return {"provider": "mock", "model_name": "mock-from-named-default"}
+            return None
+        mock_app_config_in_main.get_llm_config.side_effect = get_llm_config_side_effect
+        mock_app_config_in_main.get_all_llm_configs.return_value = {"default-llm-name": {"provider": "mock", "model_name": "mock-from-named-default"}}
+
+        # To make the actual Config load this temporary file for the factory, we use the env var.
+        # The factory `create_llm_provider` receives `app_config` (which is `mock_app_config_in_main`).
+        # The factory will use this `app_config`'s methods first.
+        # If `actual_llm_config_name` is determined (from default_model_id), it calls `app_config.get_llm_config(actual_llm_config_name)`.
+        # This is already mocked above. So, env var might not be strictly needed here IF the `app_config` passed to factory is the one we mock.
+        # The CLI command gets `app_config = ctx.obj['config']`. `compact_memory.main.app_config` is the source of this.
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--budget", "50",
+            ],
+             # The env var is crucial if the Config object in the factory needs to load the file itself,
+             # but since we mock get_llm_config on the instance passed to the factory, it might be okay.
+             # However, the factory itself might instantiate a new Config() if app_config=None.
+             # The CLI passes the app_config from context, so that path is not taken.
+            env={"COMPACT_MEMORY_LLM_MODELS_CONFIG_PATH": str(temp_config_file_path)} # Still good for safety.
+        )
+
+        self.assertEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("No LLM specified directly; using default from config: default-llm-name", result.stdout)
+        self.assertIn("MockLLMProvider", result.stdout)
+        self.assertIn("GistModel: mock-from-named-default", result.stdout)
+
+    @mock.patch('compact_memory.main.app_config')
+    def test_compress_error_if_default_model_id_invalid_format(self, mock_app_config_in_main):
+        mock_app_config_in_main.get.side_effect = lambda key, default=None: "invalid_default/format/extra_slash" if key == "default_model_id" else default
+        mock_app_config_in_main.get_llm_config.return_value = None
+        mock_app_config_in_main.get_all_llm_configs.return_value = {}
+
+        result = self.runner.invoke(
+            app,
+            [
+                "compress", str(self.input_file),
+                "--engine", DummyLLMEngine.id,
+                "--budget", "50"
+            ]
+        )
+        self.assertNotEqual(result.exit_code, 0, msg=result.stdout)
+        self.assertIn("Error: Default model ID 'invalid_default/format/extra_slash' is not a valid", result.stdout)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -1,0 +1,141 @@
+import os
+import unittest
+from unittest import mock
+import sys
+
+# Ensure compact_memory is discoverable if tests are run directly
+# This might not be needed if using pytest and proper project structure/installation
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from compact_memory.llm_providers.factory import create_llm_provider
+from compact_memory.llm_providers_abc import LLMProvider
+from compact_memory.llm_providers import OpenAIProvider, MockLLMProvider
+from compact_memory.config import Config
+
+# Attempt to import optional providers for more complete testing if available
+try:
+    from compact_memory.llm_providers import LocalTransformersProvider
+except ImportError:
+    LocalTransformersProvider = None
+
+try:
+    from compact_memory.llm_providers import GeminiProvider
+except ImportError:
+    GeminiProvider = None
+
+
+class TestLLMProviderFactory(unittest.TestCase):
+
+    def setUp(self):
+        # Store and clear relevant environment variables before each test
+        self.original_openai_api_key = os.environ.get("OPENAI_API_KEY")
+        self.original_google_api_key = os.environ.get("GOOGLE_API_KEY")
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+        if "GOOGLE_API_KEY" in os.environ:
+            del os.environ["GOOGLE_API_KEY"]
+
+    def tearDown(self):
+        # Restore original environment variables
+        if self.original_openai_api_key is not None:
+            os.environ["OPENAI_API_KEY"] = self.original_openai_api_key
+        elif "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+
+        if self.original_google_api_key is not None:
+            os.environ["GOOGLE_API_KEY"] = self.original_google_api_key
+        elif "GOOGLE_API_KEY" in os.environ:
+            del os.environ["GOOGLE_API_KEY"]
+
+    @mock.patch.object(Config, "get_llm_config")
+    @mock.patch.object(Config, "get_all_llm_configs")
+    def test_create_with_named_config_mock(self, mock_get_all_configs, mock_get_config):
+        mock_get_config.return_value = {"provider": "mock"}
+        provider = create_llm_provider(config_name="my-mock-config", app_config=Config())
+        self.assertIsInstance(provider, MockLLMProvider)
+        mock_get_config.assert_called_with("my-mock-config")
+
+    @mock.patch.object(Config, "get_llm_config")
+    @mock.patch.object(Config, "get_all_llm_configs")
+    def test_create_with_named_config_openai(self, mock_get_all_configs, mock_get_config):
+        mock_get_config.return_value = {"provider": "openai", "api_key": "fake_key_from_config"}
+        provider = create_llm_provider(config_name="my-openai-config", app_config=Config())
+        self.assertIsInstance(provider, OpenAIProvider)
+        self.assertEqual(os.environ.get("OPENAI_API_KEY"), "fake_key_from_config")
+
+    @mock.patch.object(Config, "get_llm_config")
+    @mock.patch.object(Config, "get_all_llm_configs")
+    def test_create_with_named_config_not_found(self, mock_get_all_configs, mock_get_config):
+        mock_get_config.return_value = None
+        mock_get_all_configs.return_value = {"existing-config": {}}
+        with self.assertRaisesRegex(ValueError, "LLM configuration 'nonexistent-config' not found"):
+            create_llm_provider(config_name="nonexistent-config", app_config=Config())
+
+    def test_create_with_direct_provider_mock(self):
+        provider = create_llm_provider(provider_type="mock")
+        self.assertIsInstance(provider, MockLLMProvider)
+
+    def test_create_with_direct_provider_openai(self):
+        provider = create_llm_provider(provider_type="openai", api_key="direct_test_key")
+        self.assertIsInstance(provider, OpenAIProvider)
+        self.assertEqual(os.environ.get("OPENAI_API_KEY"), "direct_test_key")
+
+    def test_create_with_unknown_provider_type(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported LLM provider type: 'unknown_provider'"):
+            create_llm_provider(provider_type="unknown_provider")
+
+    def test_api_key_handling_openai_from_config_overrides_direct_if_config_name_passed(self):
+        # If config_name is passed, its api_key should be used, even if api_key param is also passed.
+        # The factory logic prioritizes values from the named config.
+        with mock.patch.object(Config, 'get_llm_config', return_value={'provider': 'openai', 'api_key': 'config_key'}):
+            provider = create_llm_provider(config_name="some-config", api_key="direct_key_ignored", app_config=Config())
+            self.assertIsInstance(provider, OpenAIProvider)
+            self.assertEqual(os.environ.get("OPENAI_API_KEY"), "config_key")
+
+    def test_api_key_handling_openai_direct_used_if_no_config_name(self):
+        provider = create_llm_provider(provider_type="openai", api_key="direct_key_used")
+        self.assertIsInstance(provider, OpenAIProvider)
+        self.assertEqual(os.environ.get("OPENAI_API_KEY"), "direct_key_used")
+
+
+    def test_value_error_if_no_provider_type_determinable(self):
+        # No config_name, no provider_type
+        with self.assertRaisesRegex(ValueError, "LLM provider type must be specified"):
+            create_llm_provider(app_config=Config()) # Pass empty config
+
+    @unittest.skipIf(LocalTransformersProvider is None, "LocalTransformersProvider not available (transformers/torch probably missing)")
+    def test_create_local_provider_when_available(self):
+        provider = create_llm_provider(provider_type="local")
+        self.assertIsInstance(provider, LocalTransformersProvider)
+
+    @mock.patch('compact_memory.llm_providers.factory.LocalTransformersProvider', None)
+    def test_create_local_provider_import_error_if_set_to_none(self):
+        # This simulates LocalTransformersProvider being None in factory's scope due to initial import error in __init__.py
+        with self.assertRaisesRegex(ImportError, "Local LLM provider \(LocalTransformersProvider\) could not be imported.*LocalTransformersProvider is None"):
+            create_llm_provider(provider_type="local")
+
+    @mock.patch.dict(sys.modules, {'compact_memory.llm_providers.local_provider': None})
+    def test_create_local_provider_import_error_on_module_level(self):
+        # This simulates the local_provider module itself not being importable
+         with self.assertRaisesRegex(ImportError, "Local LLM provider \(LocalTransformersProvider\) could not be imported."):
+            create_llm_provider(provider_type="local")
+
+
+    @unittest.skipIf(GeminiProvider is None, "GeminiProvider not available (google-generativeai probably missing)")
+    def test_create_gemini_provider_when_available(self):
+        provider = create_llm_provider(provider_type="gemini", api_key="gemini_test_key")
+        self.assertIsInstance(provider, GeminiProvider)
+        self.assertEqual(os.environ.get("GOOGLE_API_KEY"), "gemini_test_key")
+
+    @mock.patch('compact_memory.llm_providers.factory.GeminiProvider', None)
+    def test_create_gemini_provider_import_error_if_set_to_none(self):
+        with self.assertRaisesRegex(ImportError, "Gemini LLM provider \(GeminiProvider\) could not be imported.*GeminiProvider is None"):
+            create_llm_provider(provider_type="gemini")
+
+    @mock.patch.dict(sys.modules, {'compact_memory.llm_providers.gemini_provider': None})
+    def test_create_gemini_provider_import_error_on_module_level(self):
+         with self.assertRaisesRegex(ImportError, "Gemini LLM provider \(GeminiProvider\) could not be imported."):
+            create_llm_provider(provider_type="gemini")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've implemented comprehensive CLI support for configuring LLM providers for LLM-dependent compression engines like ReadAgentGistEngine.

Key features include:

1.  **CLI Options:**
    *   New flags for `compact-memory compress` and `compact-memory engine init`:
        *   `--llm-config NAME`: Use a predefined LLM setup from `llm_models_config.yaml`.
        *   `--llm-provider-type TYPE`: Specify provider (local, openai, mock, gemini).
        *   `--llm-model-name NAME_OR_PATH`: Specify the model.
        *   `--llm-api-key KEY`: Provide API key directly.
        *   `--readagent-*` flags: Fine-tune parameters for ReadAgentGistEngine phases (gist model/length, lookup tokens, QA model/tokens).
    *   Input validation ensures mutual exclusivity for `--llm-config` vs. direct flags, and pairing of provider/model flags.

2.  **Configuration Handling:**
    *   Utilizes `llm_models_config.yaml` for named configurations.
    *   Falls back to global `default_model_id` (from main config or environment variable `COMPACT_MEMORY_DEFAULT_MODEL_ID`) if no specific LLM flags are provided.
    *   Clear error messages guide you if LLM configuration is missing or invalid.

3.  **LLMProviderFactory:**
    *   A new factory (`create_llm_provider`) centralizes LLM provider instantiation.
    *   Supports `local`, `openai`, `mock`, and `gemini` providers.
    *   Handles API key injection (currently via environment variables within the factory).

4.  **Engine Integration:**
    *   CLI commands now detect if an engine (identified by `EngineCls.requires_llm = True`) needs an LLM.
    *   The `LLMProvider` instance and engine-specific configs (derived from `readagent_*` flags or defaults) are passed to the engine constructor.

5.  **Testing:**
    *   I've added extensive unit tests for `LLMProviderFactory`, including handling of optional dependencies (local, gemini) and API key logic.
    *   I've also included comprehensive integration tests for CLI `compress` command using a `DummyLLMEngine`:
        *   Verifies error handling for missing/invalid LLM configs.
        *   Tests successful operation with `--llm-config` and direct flags.
        *   Confirms `readagent_*` flag overrides and model name propagation.
        *   Validates fallback to `default_model_id`.

6.  **Documentation:**
    *   Updated `docs/cli_reference.md` with new flags and usage examples for `compress` and `engine init`.
    *   Added documentation for `llm_models_config.yaml` format and usage in `docs/configuration.md`.
    *   Included a general note in `docs/COMPRESSION_ENGINES.md` about LLM requirements for some engines.

This integration provides you with flexible and robust mechanisms for configuring LLMs, enhancing the capabilities of engines that leverage them.