### PR TITLE
Document ReadAgent OpenAI test results

### DIFF
--- a/docs/READAGENT_OPENAI_TEST.md
+++ b/docs/READAGENT_OPENAI_TEST.md
@@ -1,0 +1,27 @@
+# Testing ReadAgentGistEngine with OpenAIProvider
+
+This document records a quick attempt to run the ReadAgent engine using the `OpenAIProvider`.
+
+## Setup
+1. Downloaded the default embedding model required by the engine:
+   ```bash
+   compact-memory dev download-embedding-model --model-name all-MiniLM-L6-v2
+   ```
+2. Tried to instantiate `ReadAgentGistEngine` with `OpenAIProvider` and run a simple summarization task.
+
+## Observations
+- Engine initialization fails during gist generation with the following message:
+  ````
+  Error calling llm_provider for gisting:
+  
+  You tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.
+  ````
+- Earlier versions of `OpenAIProvider` used the pre-v1 `ChatCompletion.create` interface which was incompatible with `openai` version 1.84.0 installed in this environment. The provider now uses the official `openai.chat.completions.create` API.
+
+## Suggestions
+- Update `OpenAIProvider.generate_response` to use the new API (`openai.chat.completions.create`).
+- Consider adding an API version check or pinning the `openai` dependency to avoid unexpected breaks.
+
+## Questions
+- Should the engine provide clearer feedback when the provider fails due to API changes?
+- Are there plans to support asynchronous LLM calls for improved throughput?

--- a/examples/llm_helpers.py
+++ b/examples/llm_helpers.py
@@ -45,12 +45,12 @@ def run_openai(
     if api_key:
         openai.api_key = api_key
     messages = [{"role": "user", "content": prompt}]
-    resp = openai.ChatCompletion.create(
+    resp = openai.chat.completions.create(
         model=model_name,
         messages=messages,
         max_tokens=max_new_tokens,
     )
-    return resp.choices[0].message["content"].strip()
+    return resp.choices[0].message.content.strip()
 
 
 def run_local(

--- a/src/compact_memory/llm_providers/openai_provider.py
+++ b/src/compact_memory/llm_providers/openai_provider.py
@@ -43,10 +43,10 @@ class OpenAIProvider(LLMProvider):
         if api_key:
             openai.api_key = api_key
         messages = [{"role": "user", "content": prompt}]
-        resp = openai.ChatCompletion.create(
+        resp = openai.chat.completions.create(
             model=model_name,
             messages=messages,
             max_tokens=max_new_tokens,
             **llm_kwargs,
         )
-        return resp.choices[0].message["content"].strip()
+        return resp.choices[0].message.content.strip()

--- a/src/compact_memory/memory_creation.py
+++ b/src/compact_memory/memory_creation.py
@@ -63,14 +63,14 @@ class LLMSummaryCreator(MemoryCreator):
     def create(self, text: str) -> str:
         import openai
 
-        resp = openai.ChatCompletion.create(
+        resp = openai.chat.completions.create(
             model=self.model,
             messages=[
                 {"role": "system", "content": "Summarise the following text."},
                 {"role": "user", "content": text},
             ],
         )
-        return resp["choices"][0]["message"]["content"].strip()
+        return resp.choices[0].message.content.strip()
 
 
 class AgenticMemoryCreator(MemoryCreator):

--- a/tests/test_memory_creation.py
+++ b/tests/test_memory_creation.py
@@ -42,9 +42,16 @@ def test_llm_summary_creator(monkeypatch):
     class Dummy:
         @staticmethod
         def create(*args, **kwargs):
-            return {"choices": [{"message": {"content": "summary"}}]}
+            from types import SimpleNamespace
+
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="summary"))]
+            )
+
     import openai
-    monkeypatch.setattr(openai.ChatCompletion, "create", Dummy.create)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(openai.chat.completions, "create", Dummy.create)
     creator = LLMSummaryCreator(model="dummy")
     assert creator.create("text") == "summary"
 


### PR DESCRIPTION
## Summary
- document results of running ReadAgent with OpenAI provider
- update OpenAI provider to use new chat completions API
- update helpers and summary creator accordingly
- clarify doc about deprecated ChatCompletion interface

## Testing
- `pre-commit run --files docs/READAGENT_OPENAI_TEST.md examples/llm_helpers.py src/compact_memory/llm_providers/openai_provider.py src/compact_memory/memory_creation.py tests/test_memory_creation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439204d6bc8329a7bf069f68f17a43