### PR TITLE
Add OpenAI-compatible provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ the Codex environment and is not needed for general users.
     ```bash
     export OPENAI_API_KEY="sk-..."
     export GEMINI_API_KEY="..."
+    # For OpenAI-compatible endpoints (e.g., hosted via liteLLM)
+    export OPENAI_BASE_URL="https://my-endpoint.example.com/v1"
     ```
 
 Run `compact-memory --help` to see available commands and verify installation.
@@ -386,6 +388,8 @@ compact-memory --memory-path ./my_memory query "What was mentioned about project
 
 # You can also override the default model or engine for a specific query:
 compact-memory query "Summarize recent findings on AI ethics" --model-id openai/gpt-4-turbo --engine prototype
+# Use an OpenAI-compatible provider
+compact-memory --provider openai --provider-url https://my-endpoint.example.com/v1 --provider-key $OPENAI_API_KEY query "Tell me about compact memory"
 ```
 
 **5. Compress Text (Standalone Utility):**

--- a/src/compact_memory/cli/main.py
+++ b/src/compact_memory/cli/main.py
@@ -84,6 +84,24 @@ def main_callback(  # Renamed from main to main_callback for clarity
         help="Default compression engine ID (e.g., for history, one-shot compress). Overrides env var/config.",
         show_default=False,
     ),
+    provider: Optional[str] = typer.Option(
+        None,
+        "--provider",
+        help="Override LLM provider for this invocation (e.g., openai).",
+        show_default=False,
+    ),
+    provider_url: Optional[str] = typer.Option(
+        None,
+        "--provider-url",
+        help="Base URL for an OpenAI-compatible provider.",
+        show_default=False,
+    ),
+    provider_key: Optional[str] = typer.Option(
+        None,
+        "--provider-key",
+        help="API key for the OpenAI-compatible provider.",
+        show_default=False,
+    ),
     version: Optional[bool] = typer.Option(  # version_callback handles this
         None,
         "-v",
@@ -148,6 +166,10 @@ def main_callback(  # Renamed from main to main_callback for clarity
         engine_id if engine_id is not None else config.get("default_engine_id")
     )
 
+    resolved_provider = provider if provider is not None else None
+    resolved_provider_url = provider_url if provider_url is not None else None
+    resolved_provider_key = provider_key if provider_key is not None else None
+
     # Store resolved values in context for subcommands
     ctx.obj["config"] = config  # The Config instance itself
     ctx.obj["verbose"] = resolved_verbose
@@ -155,6 +177,9 @@ def main_callback(  # Renamed from main to main_callback for clarity
     ctx.obj["compact_memory_path"] = resolved_memory_path_str
     ctx.obj["default_model_id"] = resolved_model_id
     ctx.obj["default_engine_id"] = resolved_engine_id
+    ctx.obj["provider_override"] = resolved_provider
+    ctx.obj["provider_url"] = resolved_provider_url
+    ctx.obj["provider_key"] = resolved_provider_key
 
     # Load plugins after configuration is sorted out
     try:


### PR DESCRIPTION
## Summary
- extend `OpenAIProvider` to accept custom base URL and API key
- expose new CLI options `--provider`, `--provider-url`, and `--provider-key`
- allow provider overrides in compression commands
- document provider URL usage in README

## Testing
- `pre-commit run --files src/compact_memory/cli/compress_commands.py src/compact_memory/cli/main.py src/compact_memory/llm_providers/__init__.py src/compact_memory/llm_providers/openai_provider.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843983c3fe48329aea84f8182c80a2c