### PR TITLE
Add embedding and LLM judge metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ This project requires **Python 3.11+**.
    pip install .[local]        # for local Transformers models
    pip install .[gemini]       # Google Gemini provider
    pip install .[metrics]      # Hugging Face evaluation metrics
+   # LLM judge metric uses the OpenAI API which is already a core dependency
+   # Install both extras if you plan to use embedding or LLM-based metrics
    ```
    To run the full test suite with all heavy packages, install additional
    dependencies:
@@ -405,6 +407,7 @@ Compact Memory also includes tools for developers and researchers, such as evalu
 For example, to evaluate compression quality:
 ```bash
 compact-memory dev evaluate-compression original.txt compressed_version.txt --metric compression_ratio
+compact-memory dev evaluate-llm-response model_answer.txt reference.txt --metric rouge_hf
 ```
 To list available engines (including plugins):
 ```bash

--- a/docs/DEVELOPING_VALIDATION_METRICS.md
+++ b/docs/DEVELOPING_VALIDATION_METRICS.md
@@ -43,3 +43,31 @@ class RougeMetric(HFValidationMetric):
 ```
 
 Metrics are selected by `metric_id` and optional initialisation parameters.
+
+## Embedding-based Metrics
+
+`EmbeddingSimilarityMetric` computes cosine similarity between sentence
+embeddings. It relies on the optional `sentence-transformers` dependency.
+Install it with `pip install compact-memory[embedding]`.
+
+```python
+from compact_memory.validation.embedding_metrics import EmbeddingSimilarityMetric
+
+metric = EmbeddingSimilarityMetric(model_name="all-MiniLM-L6-v2")
+scores = metric.evaluate(original_text="a", compressed_text="b")
+```
+
+## LLM Judge Metric
+
+`LLMJudgeMetric` queries an OpenAI chat model to score text pairs. The metric
+caches results in memory to avoid repeated API calls.
+
+```python
+from compact_memory.validation.llm_judge_metric import LLMJudgeMetric
+
+metric = LLMJudgeMetric(model_name="gpt-4")
+score = metric.evaluate(llm_response=model_answer, reference_answer=truth)
+```
+
+Ensure your `OPENAI_API_KEY` environment variable is set before using this
+metric.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -157,6 +157,20 @@ Group of commands for compression engine developers and researchers.
 
 Lists all available validation metric IDs that can be used in evaluations.
 
+Example output:
+
+```
+Available validation metric IDs:
+- rouge_hf
+- bleu_hf
+- meteor_hf
+- bertscore_hf
+- exact_match
+- compression_ratio
+- embedding_similarity
+- llm_judge
+```
+
 #### `compact-memory dev list-engines` (also `list-strategies`)
 
 Lists all available compression engine IDs, their versions, and sources (built-in or plugin).
@@ -199,6 +213,9 @@ Tests a Language Model (LLM) prompt with specified context and query.
 #### `compact-memory dev evaluate-llm-response RESPONSE_INPUT REFERENCE_INPUT`
 
 Evaluates an LLM's response against a reference answer using a specified metric.
+
+The `llm_judge` metric requires an OpenAI API key available in the
+`OPENAI_API_KEY` environment variable.
 
 *   **`RESPONSE_INPUT`**: (Required) LLM's response text/file/-.
 *   **`REFERENCE_INPUT`**: (Required) Reference answer text/file/-.

--- a/src/compact_memory/validation/__init__.py
+++ b/src/compact_memory/validation/__init__.py
@@ -25,3 +25,17 @@ else:
         "BertScoreHFMetric",
         "ExactMatchMetric",
     ]
+
+try:  # embedding dependencies may be missing
+    from .embedding_metrics import EmbeddingSimilarityMetric
+except Exception:  # pragma: no cover - optional dependency may be missing
+    EmbeddingSimilarityMetric = None  # type: ignore
+else:
+    __all__ += ["EmbeddingSimilarityMetric"]
+
+try:
+    from .llm_judge_metric import LLMJudgeMetric
+except Exception:  # pragma: no cover - optional dependency may be missing
+    LLMJudgeMetric = None  # type: ignore
+else:
+    __all__ += ["LLMJudgeMetric"]

--- a/src/compact_memory/validation/embedding_metrics.py
+++ b/src/compact_memory/validation/embedding_metrics.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Embedding-based validation metrics."""
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from .. import embedding_pipeline as ep
+from .metrics_abc import ValidationMetric
+from .registry import register_validation_metric
+
+
+class EmbeddingSimilarityMetric(ValidationMetric):
+    """Cosine similarity between embeddings of two texts."""
+
+    metric_id = "embedding_similarity"
+
+    def evaluate(
+        self,
+        *,
+        original_text: Optional[str] = None,
+        compressed_text: Optional[str] = None,
+        llm_response: Optional[str] = None,
+        reference_answer: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if original_text is not None and compressed_text is not None:
+            text_a, text_b = original_text, compressed_text
+        elif llm_response is not None and reference_answer is not None:
+            text_a, text_b = reference_answer, llm_response
+        else:
+            raise ValueError(
+                "EmbeddingSimilarityMetric requires original/compressed texts or response/reference texts."
+            )
+
+        if not text_a or not text_b:
+            return {"semantic_similarity": 0.0}
+
+        embed_kwargs = {}
+        for key in ["model_name", "device", "batch_size"]:
+            if key in self.config_params:
+                embed_kwargs[key] = self.config_params[key]
+
+        vecs = ep.embed_text([text_a, text_b], **embed_kwargs)
+        score = float(np.dot(vecs[0], vecs[1]))
+        return {"semantic_similarity": score}
+
+
+register_validation_metric(
+    EmbeddingSimilarityMetric.metric_id, EmbeddingSimilarityMetric
+)
+
+__all__ = ["EmbeddingSimilarityMetric"]

--- a/src/compact_memory/validation/llm_judge_metric.py
+++ b/src/compact_memory/validation/llm_judge_metric.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""LLM-based evaluation metric using OpenAI chat models."""
+
+from typing import Any, Dict, Optional
+import hashlib
+
+import openai
+
+from .metrics_abc import ValidationMetric
+from .registry import register_validation_metric
+
+_CACHE: dict[str, float] = {}
+
+
+class LLMJudgeMetric(ValidationMetric):
+    """Score text pairs by querying an OpenAI model."""
+
+    metric_id = "llm_judge"
+
+    DEFAULT_ANSWER_PROMPT = (
+        "You are an expert grader. "
+        "Given a model's answer and the reference correct answer, "
+        "score how correct the model answer is on a scale from 0 to 1. "
+        "Only output the numeric score."
+    )
+
+    DEFAULT_SUMMARY_PROMPT = (
+        "You are an evaluator of summaries. "
+        "Given an original text and its compressed summary, "
+        "score how well the summary preserves the important information on a scale from 0 to 1. "
+        "Only output the numeric score."
+    )
+
+    def __init__(self, model_name: str = "gpt-3.5-turbo", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.model_name = model_name
+        self.client = openai.OpenAI()
+
+    def _score_pair(self, system_prompt: str, text_a: str, text_b: str) -> float:
+        key = hashlib.sha256(
+            "||".join([system_prompt, text_a, text_b]).encode()
+        ).hexdigest()
+        if key in _CACHE:
+            return _CACHE[key]
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": f"Text A:\n{text_a}\n\nText B:\n{text_b}\n\nScore:",
+            },
+        ]
+        resp = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=messages,
+            temperature=0,
+        )
+        try:
+            score = float(resp.choices[0].message.content.strip())
+        except Exception as exc:
+            raise RuntimeError(f"Invalid LLM judge response: {resp}") from exc
+        _CACHE[key] = score
+        return score
+
+    def evaluate(
+        self,
+        *,
+        original_text: Optional[str] = None,
+        compressed_text: Optional[str] = None,
+        llm_response: Optional[str] = None,
+        reference_answer: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if original_text is not None and compressed_text is not None:
+            prompt = self.config_params.get(
+                "summary_prompt", self.DEFAULT_SUMMARY_PROMPT
+            )
+            score = self._score_pair(prompt, original_text, compressed_text)
+        elif llm_response is not None and reference_answer is not None:
+            prompt = self.config_params.get("answer_prompt", self.DEFAULT_ANSWER_PROMPT)
+            score = self._score_pair(prompt, reference_answer, llm_response)
+        else:
+            raise ValueError(
+                "LLMJudgeMetric requires original/compressed texts or response/reference texts."
+            )
+        return {"llm_judge_score": score}
+
+
+register_validation_metric(LLMJudgeMetric.metric_id, LLMJudgeMetric)
+
+__all__ = ["LLMJudgeMetric"]

--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from typer.testing import CliRunner
+from compact_memory.cli import app
+
+runner = CliRunner(env={"MIX_STDERR": "False"})
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "COMPACT_MEMORY_DEFAULT_ENGINE_ID": "none",
+        "COMPACT_MEMORY_DEFAULT_MODEL_ID": "tiny-gpt2",
+    }
+
+
+def test_list_metrics(tmp_path: Path):
+    result = runner.invoke(app, ["dev", "list-metrics"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    assert "compression_ratio" in result.stdout
+    assert "embedding_similarity" in result.stdout
+
+
+def test_evaluate_compression_cli(tmp_path: Path, patch_embedding_model):
+    result = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-compression",
+            "hello",
+            "hello",
+            "--metric",
+            "embedding_similarity",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert "semantic_similarity" in result.stdout
+
+
+def test_evaluate_llm_response_cli(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "dev",
+            "evaluate-llm-response",
+            "hello",
+            "hello",
+            "--metric",
+            "exact_match",
+        ],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert "exact_match" in result.stdout

--- a/tests/test_embedding_similarity_metric.py
+++ b/tests/test_embedding_similarity_metric.py
@@ -1,0 +1,14 @@
+import numpy as np
+from compact_memory.validation.embedding_metrics import EmbeddingSimilarityMetric
+
+
+def test_embedding_similarity_identical(patch_embedding_model):
+    metric = EmbeddingSimilarityMetric()
+    scores = metric.evaluate(original_text="hello", compressed_text="hello")
+    assert np.isclose(scores["semantic_similarity"], 1.0)
+
+
+def test_embedding_similarity_different(patch_embedding_model):
+    metric = EmbeddingSimilarityMetric()
+    scores = metric.evaluate(original_text="hello", compressed_text="world")
+    assert scores["semantic_similarity"] < 1.0

--- a/tests/test_hf_metrics_simple.py
+++ b/tests/test_hf_metrics_simple.py
@@ -1,0 +1,21 @@
+from compact_memory.validation.hf_metrics import (
+    BleuHFMetric,
+    ExactMatchMetric,
+)
+
+
+def test_exact_match_metric():
+    metric = ExactMatchMetric()
+    assert (
+        metric.evaluate(llm_response="hi", reference_answer="hi")["exact_match"] == 1.0
+    )
+    assert (
+        metric.evaluate(llm_response="hi", reference_answer="bye")["exact_match"] == 0.0
+    )
+
+
+def test_bleu_metric_basic():
+    metric = BleuHFMetric()
+    scores = metric.evaluate(llm_response="hello world", reference_answer="hello world")
+    assert "bleu" in scores
+    assert isinstance(scores["bleu"], float)

--- a/tests/test_llm_judge_metric.py
+++ b/tests/test_llm_judge_metric.py
@@ -1,0 +1,30 @@
+from compact_memory.validation.llm_judge_metric import LLMJudgeMetric
+import openai
+
+
+class DummyClient:
+    def __init__(self):
+        self.call_count = 0
+        self.chat = self
+        self.completions = self
+
+    def create(self, model, messages, temperature=0):
+        self.call_count += 1
+
+        class R:
+            choices = [
+                type("Msg", (), {"message": type("M", (), {"content": "0.8"})()})
+            ]
+
+        return R()
+
+
+def test_llm_judge_metric(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(openai, "OpenAI", lambda *a, **k: dummy)
+    metric = LLMJudgeMetric(model_name="gpt-x")
+    res1 = metric.evaluate(llm_response="foo", reference_answer="foo")
+    res2 = metric.evaluate(llm_response="foo", reference_answer="foo")
+    assert res1["llm_judge_score"] == 0.8
+    assert dummy.call_count == 1
+    assert res2["llm_judge_score"] == 0.8


### PR DESCRIPTION
## Summary
- add `EmbeddingSimilarityMetric` for cosine similarity scoring
- implement OpenAI-based `LLMJudgeMetric`
- register new metrics and document usage
- include CLI examples and docs for optional extras
- test metrics and CLI integration

## Testing
- `pre-commit run --files src/compact_memory/validation/embedding_metrics.py src/compact_memory/validation/llm_judge_metric.py src/compact_memory/validation/__init__.py docs/DEVELOPING_VALIDATION_METRICS.md README.md docs/cli_reference.md tests/test_embedding_similarity_metric.py tests/test_hf_metrics_simple.py tests/test_llm_judge_metric.py tests/test_cli_metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844494380ec8329aeef71d5abf5df74