### PR TITLE
Fix decode for first_last engine

### DIFF
--- a/src/compact_memory/engines/first_last_engine.py
+++ b/src/compact_memory/engines/first_last_engine.py
@@ -47,8 +47,13 @@ class FirstLastEngine(BaseCompressionEngine):
             kept_tokens = tokens[:half] + tokens[-half:]
 
         if hasattr(tokenizer, "decode"):
-            try:
+            try:  # Prefer to drop special tokens if supported
                 kept = tokenizer.decode(kept_tokens, skip_special_tokens=True)
+            except TypeError:  # e.g. tiktoken decode has no skip_special_tokens
+                try:
+                    kept = tokenizer.decode(kept_tokens)
+                except Exception:
+                    kept = " ".join(str(t) for t in kept_tokens)
             except Exception:
                 kept = " ".join(str(t) for t in kept_tokens)
         else:


### PR DESCRIPTION
## Summary
- ensure token decoding works with tiktoken

## Testing
- `pre-commit run --files src/compact_memory/engines/first_last_engine.py`
- `pytest -q` *(fails: ImportError: The 'evaluate' package is required)*

------
https://chatgpt.com/codex/tasks/task_e_684450615ca483298c3b56412f86d1c7