### PR TITLE
Standardize ReadAgent engine name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ portable.
 - Format Python code with **Black** and lint with **Flake8**. Run `pre-commit run --files <files>` before committing.
 - Follow **PEP 8** and include type hints for functions and methods.
 - Write clear docstrings in the Google style.
+- Name compression engine `id` strings using lowercase `snake_case` so they can be used with the `--engine` CLI option.
 
 ## Testing
 - Run `pytest` from the repository root after making code changes.

--- a/src/compact_memory/engines/ReadAgent/engine.py
+++ b/src/compact_memory/engines/ReadAgent/engine.py
@@ -30,7 +30,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 class ReadAgentGistEngine(BaseCompressionEngine):
-    id: str = "readagent_gist"
+    id: str = "read_agent_gist"
 
     def __init__(
         self,

--- a/tests/engines/test_readagent_gist_engine.py
+++ b/tests/engines/test_readagent_gist_engine.py
@@ -290,7 +290,7 @@ class TestReadAgentGistEngine(unittest.TestCase):
                     "50",  # If LLM output is >50, it would be truncated by the CLI wrapper normally.
                     # Here, mock_llm_output is shorter than 50.
                     "--engine",
-                    "readagent_gist",
+                    "read_agent_gist",
                     # No --model-id, so it should pick up default_model_id from global config to select the provider.
                 ],
             )


### PR DESCRIPTION
## Summary
- rename `ReadAgentGistEngine.id` to `read_agent_gist`
- remove the temporary `ReadAgent` aliases
- document engine naming in `AGENTS.md`
- update test CLI invocation

## Testing
- `pre-commit run --files AGENTS.md src/compact_memory/engines/ReadAgent/engine.py tests/engines/test_readagent_gist_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68444fcf42888329a18a118929a2b94f