### PR TITLE
Improve LLMJudgeMetric API key handling

### DIFF
--- a/docs/DEVELOPING_VALIDATION_METRICS.md
+++ b/docs/DEVELOPING_VALIDATION_METRICS.md
@@ -70,4 +70,4 @@ score = metric.evaluate(llm_response=model_answer, reference_answer=truth)
 ```
 
 Ensure your `OPENAI_API_KEY` environment variable is set before using this
-metric.
+metric. The metric raises a `RuntimeError` if no API key is found.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -215,7 +215,8 @@ Tests a Language Model (LLM) prompt with specified context and query.
 Evaluates an LLM's response against a reference answer using a specified metric.
 
 The `llm_judge` metric requires an OpenAI API key available in the
-`OPENAI_API_KEY` environment variable.
+`OPENAI_API_KEY` environment variable. If the key is missing, the metric
+raises a clear `RuntimeError`.
 
 *   **`RESPONSE_INPUT`**: (Required) LLM's response text/file/-.
 *   **`REFERENCE_INPUT`**: (Required) Reference answer text/file/-.

--- a/src/compact_memory/validation/llm_judge_metric.py
+++ b/src/compact_memory/validation/llm_judge_metric.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 import hashlib
+import os
 
 import openai
 
@@ -35,7 +36,10 @@ class LLMJudgeMetric(ValidationMetric):
     def __init__(self, model_name: str = "gpt-3.5-turbo", **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.model_name = model_name
-        self.client = openai.OpenAI()
+        api_key = kwargs.pop("api_key", None) or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY environment variable not set")
+        self.client = openai.OpenAI(api_key=api_key)
 
     def _score_pair(self, system_prompt: str, text_a: str, text_b: str) -> float:
         key = hashlib.sha256(

--- a/tests/test_llm_judge_metric.py
+++ b/tests/test_llm_judge_metric.py
@@ -1,5 +1,6 @@
 from compact_memory.validation.llm_judge_metric import LLMJudgeMetric
 import openai
+import pytest
 
 
 class DummyClient:
@@ -21,6 +22,7 @@ class DummyClient:
 
 def test_llm_judge_metric(monkeypatch):
     dummy = DummyClient()
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setattr(openai, "OpenAI", lambda *a, **k: dummy)
     metric = LLMJudgeMetric(model_name="gpt-x")
     res1 = metric.evaluate(llm_response="foo", reference_answer="foo")
@@ -28,3 +30,9 @@ def test_llm_judge_metric(monkeypatch):
     assert res1["llm_judge_score"] == 0.8
     assert dummy.call_count == 1
     assert res2["llm_judge_score"] == 0.8
+
+
+def test_llm_judge_metric_missing_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        LLMJudgeMetric(model_name="gpt-x")


### PR DESCRIPTION
## Summary
- enforce `OPENAI_API_KEY` presence when constructing `LLMJudgeMetric`
- test RuntimeError when API key is missing
- document error behaviour in metric docs and CLI reference

## Testing
- `pre-commit run --files src/compact_memory/validation/llm_judge_metric.py tests/test_llm_judge_metric.py docs/DEVELOPING_VALIDATION_METRICS.md docs/cli_reference.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844581ed2cc8329bbc79fea61b16687