### PR TITLE
Fix NLTK fallback sentence splitting

### DIFF
--- a/src/compact_memory/chunker.py
+++ b/src/compact_memory/chunker.py
@@ -170,7 +170,8 @@ class NltkSentenceChunker(Chunker):
             sentences = nltk.sent_tokenize(text)
         except Exception:  # pragma: no cover - punkt not available
             # Fallback to basic split if sent_tokenize fails (e.g. punkt not downloaded)
-            sentences = text.split(".")
+            parts = [s.strip() for s in text.split(".") if s.strip()]
+            sentences = [f"{s}." for s in parts]
 
         if not sentences:
             return []

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -217,11 +217,7 @@ def test_nltk_chunker_punkt_download_failure_fallback(
     # It's testing the fallback, so precision is important.
     # If sentences are not stripped before join, spaces can accumulate.
     # The actual NltkSentenceChunker doesn't strip sentences from nltk.sent_tokenize either.
-    expected_chunks_fallback = ["One  Two  Three "]
-    if not chunks_fallback[0].endswith(
-        " "
-    ):  # Handle case where "" might be ignored by join or split differently based on python version
-        expected_chunks_fallback = ["One  Two  Three"]
+    expected_chunks_fallback = ["One. Two. Three."]
 
     assert chunks_fallback == expected_chunks_fallback
     assert "NLTK punkt download failed" in caplog.text  # Check for warning log


### PR DESCRIPTION
## Summary
- ensure punctuation preserved when nltk fails to load `punkt`
- update chunker tests for new fallback behaviour

## Testing
- `pre-commit run --files src/compact_memory/chunker.py tests/test_chunker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c0c2593c83298c49d9163cc26487