### PR TITLE
Add missing nltk and pre-commit dependencies

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -26,6 +26,9 @@ fi
 # Tools used by CI for linting and testing
 pip3 install flake8 pytest
 
+# Additional tools and libraries used in tests and linting
+pip3 install nltk pre-commit
+
 # CLI dependencies that may not be declared in requirements.txt
 # (rich and typer are already installed above)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,12 @@ dependencies = [
     "portalocker",
     "rich>=13.6",
     "platformdirs",
+    "nltk",
 ]
 
 [project.optional-dependencies]
 test = ["pytest"]
-dev = ["flake8"]
+dev = ["flake8", "pre-commit"]
 chroma = ["chromadb"]
 spacy = ["spacy"]
 optuna = ["optuna"]


### PR DESCRIPTION
## Summary
- include `nltk` in core dependencies
- add `pre-commit` to development extras
- install these tools in the Codex setup script

## Testing
- `pre-commit run --files pyproject.toml .codex/setup.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844e5e6a8dc8329a2454feb4292af09