### PR TITLE
Fix missing neocortex engine results

### DIFF
--- a/engine_metrics.json
+++ b/engine_metrics.json
@@ -7,6 +7,10 @@
     "compression_ratio": 0.2317617866004963,
     "embedding_similarity": 0.7314000129699707
   },
+  "neocortex_transfer": {
+    "compression_ratio": 0.009925558312655087,
+    "embedding_similarity": 0.6814477443695068
+  },
   "none": {
     "compression_ratio": 1.0,
     "embedding_similarity": 0.9999998807907104

--- a/src/compact_memory/engines/neocortex_transfer.py
+++ b/src/compact_memory/engines/neocortex_transfer.py
@@ -1,6 +1,7 @@
 """Cognitively inspired compression engine."""
 
 from compact_memory.engines.base import BaseCompressionEngine
+from .registry import register_compression_engine
 
 
 class NeocortexTransfer(BaseCompressionEngine):
@@ -377,6 +378,9 @@ class NeocortexTransfer(BaseCompressionEngine):
         return retrieved_candidates
 
     # TODO: Add other necessary methods and attributes as per the design.
+
+
+register_compression_engine(NeocortexTransfer.id, NeocortexTransfer, source="contrib")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- register the NeocortexTransfer engine with the engine registry
- allow `collect_engine_metrics.py` to handle engines that return a dict
- include neocortex results in engine_metrics.json

## Testing
- `pre-commit run --files examples/collect_engine_metrics.py src/compact_memory/engines/neocortex_transfer.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844f0ee77a08329ad54afc1f534f174