### PR TITLE
Add StopwordPrunerEngine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ compact-memory = "compact_memory.__main__:main"
 none = "compact_memory.engines.no_compression_engine:NoCompressionEngine"
 pipeline = "compact_memory.engines.pipeline_engine:PipelineEngine"
 first_last = "compact_memory.engines.first_last_engine:FirstLastEngine"
+stopword_pruner = "compact_memory.engines.stopword_pruner_engine:StopwordPrunerEngine"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/compact_memory/engines/registry.py
+++ b/src/compact_memory/engines/registry.py
@@ -87,6 +87,7 @@ def register_builtin_engines():
     # and to encapsulate these imports within the registration logic.
     from compact_memory.engines.no_compression_engine import NoCompressionEngine
     from compact_memory.engines.first_last_engine import FirstLastEngine
+    from compact_memory.engines.stopword_pruner_engine import StopwordPrunerEngine
 
     # PrototypeEngine was removed
 
@@ -100,6 +101,12 @@ def register_builtin_engines():
         FirstLastEngine.id,
         FirstLastEngine,
         display_name="First/Last Chunks",
+        source="built-in",
+    )
+    register_compression_engine(
+        StopwordPrunerEngine.id,
+        StopwordPrunerEngine,
+        display_name="Stopword Pruner",
         source="built-in",
     )
     # PrototypeEngine was removed

--- a/src/compact_memory/engines/stopword_pruner_engine.py
+++ b/src/compact_memory/engines/stopword_pruner_engine.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any, List, Union
+import re
+
+from compact_memory.token_utils import tokenize_text, truncate_text
+from compact_memory.spacy_utils import get_nlp, simple_sentences
+
+from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
+from .registry import register_compression_engine
+
+try:  # pragma: no cover - optional dependency
+    import nltk
+    from nltk.corpus import stopwords as nltk_stopwords
+except Exception:  # pragma: no cover - optional dependency
+    nltk = None
+    nltk_stopwords = None
+
+
+def _get_stopwords(language: str) -> set[str]:
+    """Return a set of stopwords for ``language``."""
+    if nltk_stopwords is not None:
+        try:
+            return set(nltk_stopwords.words(language))
+        except Exception:  # pragma: no cover - dataset missing
+            if nltk is not None:
+                try:
+                    nltk.download("stopwords", quiet=True)
+                    return set(nltk_stopwords.words(language))
+                except Exception:  # pragma: no cover - download failed
+                    pass
+    # Fallback minimal list
+    return {"the", "and", "is", "in", "to", "a", "of", "it", "that", "this"}
+
+
+_FILLER_WORDS = {"um", "uh", "like", "basically", "actually"}
+_TOKEN_RE = re.compile(r"\b\w+\b|[^\w\s]")
+
+
+class StopwordPrunerEngine(BaseCompressionEngine):
+    """Remove stopwords and filler content from text."""
+
+    id = "stopword_pruner"
+
+    def compress(
+        self,
+        text_or_chunks: Union[str, List[str]],
+        llm_token_budget: int | None,
+        *,
+        tokenizer: Any = None,
+        **kwargs: Any,
+    ) -> tuple[CompressedMemory, CompressionTrace]:
+        text = (
+            text_or_chunks
+            if isinstance(text_or_chunks, str)
+            else " ".join(text_or_chunks)
+        )
+
+        cfg = self.config or {}
+        preserve_order = cfg.get("preserve_order", True)
+        min_len = cfg.get("min_word_length", 1)
+        remove_fillers = cfg.get("remove_fillers", True)
+        remove_duplicates = cfg.get("remove_duplicates", False)
+        language = cfg.get("stopwords_language", "english")
+
+        stop_words = _get_stopwords(language)
+
+        nlp = get_nlp()
+        use_spacy = hasattr(nlp, "tokenizer")
+
+        removed_counts = {
+            "stopwords": 0,
+            "fillers": 0,
+            "short": 0,
+            "duplicates": 0,
+        }
+
+        output_tokens: List[str] = []
+        seen_sentences: set[str] = set()
+        prev_token_lower: str | None = None
+
+        if use_spacy:
+            doc = nlp(text)
+            sentences = doc.sents
+        else:
+            sentences = [
+                type("Span", (), {"text": s})() for s in simple_sentences(text)
+            ]
+
+        for sent in sentences:
+            sent_text = sent.text
+            if remove_duplicates and sent_text.lower() in seen_sentences:
+                removed_counts["duplicates"] += len(_TOKEN_RE.findall(sent_text))
+                continue
+            if remove_duplicates:
+                seen_sentences.add(sent_text.lower())
+
+            if use_spacy:
+                tokens = sent
+            else:
+                tokens = [
+                    type("Tok", (), {"text": t})() for t in _TOKEN_RE.findall(sent_text)
+                ]
+
+            for tok in tokens:
+                token_text = tok.text
+                lower = token_text.lower()
+                if getattr(tok, "is_space", False):
+                    continue
+                if (
+                    getattr(tok, "is_punct", False)
+                    or _TOKEN_RE.fullmatch(token_text)
+                    and not token_text.isalnum()
+                ):
+                    continue
+                if getattr(tok, "is_stop", False) or lower in stop_words:
+                    removed_counts["stopwords"] += 1
+                    continue
+                if remove_fillers and lower in _FILLER_WORDS:
+                    removed_counts["fillers"] += 1
+                    continue
+                if len(lower) < min_len:
+                    removed_counts["short"] += 1
+                    continue
+                if remove_duplicates and prev_token_lower == lower:
+                    removed_counts["duplicates"] += 1
+                    continue
+                output_tokens.append(token_text)
+                prev_token_lower = lower
+
+        if not preserve_order:
+            output_tokens = sorted(set(output_tokens))
+
+        compressed_text = " ".join(output_tokens)
+
+        tokenizer = tokenizer or (lambda t: t.split())
+        orig_tokens = len(tokenize_text(tokenizer, text))
+
+        if llm_token_budget is not None:
+            compressed_text = truncate_text(
+                tokenizer, compressed_text, llm_token_budget
+            )
+
+        compressed_tokens = len(tokenize_text(tokenizer, compressed_text))
+
+        compressed = CompressedMemory(text=compressed_text)
+        trace = CompressionTrace(
+            engine_name=self.id,
+            strategy_params={"llm_token_budget": llm_token_budget},
+            input_summary={"input_length": len(text), "input_tokens": orig_tokens},
+            steps=[
+                {"type": "remove_stopwords", "removed": removed_counts["stopwords"]},
+                {"type": "remove_fillers", "removed": removed_counts["fillers"]},
+                {"type": "remove_short", "removed": removed_counts["short"]},
+                {"type": "remove_duplicates", "removed": removed_counts["duplicates"]},
+            ],
+            output_summary={
+                "final_length": len(compressed_text),
+                "final_tokens": compressed_tokens,
+            },
+            final_compressed_object_preview=compressed_text[:50],
+        )
+        return compressed, trace
+
+
+register_compression_engine(
+    StopwordPrunerEngine.id,
+    StopwordPrunerEngine,
+    display_name="Stopword Pruner",
+    source="built-in",
+)
+
+__all__ = ["StopwordPrunerEngine"]

--- a/tests/test_cli_compress_integration.py
+++ b/tests/test_cli_compress_integration.py
@@ -25,7 +25,7 @@ def test_compress_text_input_stdout():
     assert output.startswith("Sample input text")  # original content present
 
 
-@pytest.mark.parametrize("engine_id", ["none", "first_last"])
+@pytest.mark.parametrize("engine_id", ["none", "first_last", "stopword_pruner"])
 def test_compress_text_input_all_engines(engine_id):
     text = "This is a sample text that should be compressed using various engines to test their basic functionality."
     # Provide a dummy path via env var so engines that rely on a memory path have one.

--- a/tests/test_stopword_pruner_engine.py
+++ b/tests/test_stopword_pruner_engine.py
@@ -1,0 +1,18 @@
+from compact_memory.engines.stopword_pruner_engine import StopwordPrunerEngine
+
+
+def test_stopword_pruner_basic():
+    engine = StopwordPrunerEngine()
+    text = "This is actually a very simple example, you know, just a test."
+    compressed, trace = engine.compress(text, llm_token_budget=100)
+    out = compressed.text.lower()
+    assert "actually" not in out
+    assert "is" not in out.split()
+    assert trace.engine_name == "stopword_pruner"
+
+
+def test_stopword_pruner_budget_respected():
+    engine = StopwordPrunerEngine()
+    text = "word " * 30
+    compressed, _ = engine.compress(text, llm_token_budget=5)
+    assert len(compressed.text.split()) <= 5


### PR DESCRIPTION
## Summary
- implement `StopwordPrunerEngine` for removing stopwords and filler words
- register the new engine in the built‑in registry and entry points
- test the pruner engine and CLI integration

## Testing
- `pre-commit run --files src/compact_memory/engines/stopword_pruner_engine.py src/compact_memory/engines/registry.py pyproject.toml tests/test_stopword_pruner_engine.py tests/test_cli_compress_integration.py`
- `pytest tests/test_stopword_pruner_engine.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'ActiveMemoryManager')*

------
https://chatgpt.com/codex/tasks/task_e_68459ad5ab788329ad8627fe1a38ea8a