### PR TITLE
Document multi-model embedding metric

### DIFF
--- a/docs/DEVELOPING_VALIDATION_METRICS.md
+++ b/docs/DEVELOPING_VALIDATION_METRICS.md
@@ -59,6 +59,30 @@ metric = EmbeddingSimilarityMetric(model_name="all-MiniLM-L6-v2")
 scores = metric.evaluate(original_text="a", compressed_text="b")
 ```
 
+### Multi‑model Similarity
+
+`MultiEmbeddingSimilarityMetric` (metric ID `embedding_similarity_multi`)
+accepts multiple SentenceTransformer model IDs via a `model_names` list. The
+metric reports an averaged `semantic_similarity` score along with individual
+scores for each model and a `token_count` for the evaluated pair. If the token
+count exceeds the configured `max_tokens` limit the pair is skipped.
+
+```python
+from compact_memory.validation.embedding_metrics import MultiEmbeddingSimilarityMetric
+
+metric = MultiEmbeddingSimilarityMetric(
+    model_names=["all-MiniLM-L6-v2", "multi-qa-mpnet-base-dot-v1"],
+    max_tokens=8192,
+)
+scores = metric.evaluate(original_text="hello", compressed_text="hi")
+# {
+#   "semantic_similarity": 0.98,
+#   "all-MiniLM-L6-v2": 0.99,
+#   "multi-qa-mpnet-base-dot-v1": 0.97,
+#   "token_count": 4
+# }
+```
+
 ## LLM Judge Metric
 
 `LLMJudgeMetric` queries an OpenAI chat model to score text pairs. The metric

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -26,7 +26,7 @@ These quick measurements illustrate how to evaluate engine behavior. For larger-
 
 ## Engine Metrics Script (`examples/collect_engine_metrics.py`)
 
-The `examples/collect_engine_metrics.py` script is a utility to gather `compression_ratio` and `embedding_similarity` metrics for all available (registered) compression engines in the `compact_memory` library.
+The `examples/collect_engine_metrics.py` script is a utility to gather `compression_ratio` and `embedding_similarity_multi` metrics for all available (registered) compression engines in the `compact_memory` library.
 
 By default, the script uses the text found in `tests/data/constitution.txt` as the input data for these evaluations.
 
@@ -36,11 +36,21 @@ The script outputs a JSON file (named `engine_metrics.json` by default) containi
 {
   "none": {
     "compression_ratio": 1.0,
-    "embedding_similarity": 1.0
+    "embedding_similarity_multi": {
+      "semantic_similarity": 1.0,
+      "all-MiniLM-L6-v2": 1.0,
+      "multi-qa-mpnet-base-dot-v1": 1.0,
+      "token_count": 256
+    }
   },
   "first_last": {
     "compression_ratio": 0.05,  // Example value
-    "embedding_similarity": 0.85 // Example value
+    "embedding_similarity_multi": {
+      "semantic_similarity": 0.85,
+      "all-MiniLM-L6-v2": 0.86,
+      "multi-qa-mpnet-base-dot-v1": 0.84,
+      "token_count": 128
+    }
   }
   // ... other engines
 }
@@ -48,7 +58,7 @@ The script outputs a JSON file (named `engine_metrics.json` by default) containi
 
 ### Important Considerations
 
--   The `embedding_similarity` metric produced by this script is intended to use a real sentence transformer model to provide meaningful semantic similarity scores.
+-   The `embedding_similarity_multi` metric produced by this script is intended to use real sentence transformer models to provide meaningful semantic similarity scores.
 -   The script has been updated to facilitate this by removing the `MockEncoder` override.
 -   However, running the script with a real model requires an environment with sufficient disk space and network access to download and install the model and its dependencies (e.g., `sentence-transformers`, `torch`, `nvidia-cudnn-cu12` if using CUDA).
--   If such resources are unavailable (as was the case during a recent review attempt which failed due to disk space limitations), the `embedding_similarity` scores in any generated `engine_metrics.json` might reflect a fallback or previously generated placeholder values (e.g., from `MockEncoder`) and should not be considered indicative of true semantic similarity until the script can be successfully run with a real model.
+-   If such resources are unavailable (as was the case during a recent review attempt which failed due to disk space limitations), the `embedding_similarity_multi` scores in any generated `engine_metrics.json` might reflect a fallback or previously generated placeholder values (e.g., from `MockEncoder`) and should not be considered indicative of true semantic similarity until the script can be successfully run with real models.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -167,8 +167,13 @@ Available validation metric IDs:
 - exact_match
 - compression_ratio
 - embedding_similarity
+- embedding_similarity_multi
 - llm_judge
 ```
+
+`embedding_similarity_multi` accepts `model_names` and `max_tokens` in
+`--metric-params`. It reports token counts and per-model similarity scores and
+skips pairs whose token count exceeds the limit.
 
 #### `compact-memory dev list-engines` (also `list-strategies`)
 
@@ -224,7 +229,7 @@ raises a clear `RuntimeError`.
 #### `compact-memory dev evaluate-engines`
 
 Runs multiple compression engines on the same input text and reports the
-`compression_ratio` and `embedding_similarity` metrics for each one.
+`compression_ratio` and `embedding_similarity_multi` metrics for each one.
 
 *   **Options:**
     *   `--text TEXT`: Raw text to compress, or `-` to read from stdin.

--- a/examples/collect_engine_metrics.py
+++ b/examples/collect_engine_metrics.py
@@ -13,8 +13,6 @@ from compact_memory.engines.registry import (
     register_compression_engine,
 )
 from compact_memory.validation.registry import get_validation_metric_class
-import compact_memory.embedding_pipeline as ep
-from compact_memory.embedding_pipeline import MockEncoder
 
 
 def main(output_file: str = "engine_metrics.json") -> None:
@@ -34,7 +32,10 @@ def main(output_file: str = "engine_metrics.json") -> None:
     text = Path("sample_data/moon_landing/full.txt").read_text()
 
     ratio_metric = get_validation_metric_class("compression_ratio")()
-    embed_metric = get_validation_metric_class("embedding_similarity")()
+    embed_metric = get_validation_metric_class("embedding_similarity_multi")(
+        model_names=["all-MiniLM-L6-v2", "multi-qa-mpnet-base-dot-v1"],
+        max_tokens=8192,
+    )
 
     results: dict[str, dict[str, float]] = {}
 
@@ -66,12 +67,12 @@ def main(output_file: str = "engine_metrics.json") -> None:
         ratio = ratio_metric.evaluate(original_text=text, compressed_text=comp_text)[
             "compression_ratio"
         ]
-        embed_score = embed_metric.evaluate(
+        embed_scores = embed_metric.evaluate(
             original_text=text, compressed_text=comp_text
-        )["semantic_similarity"]
+        )
         results[eng_id] = {
             "compression_ratio": ratio,
-            "embedding_similarity": embed_score,
+            "embedding_similarity_multi": embed_scores,
         }
 
     Path(output_file).write_text(json.dumps(results, indent=2))


### PR DESCRIPTION
## Summary
- add `embedding_similarity_multi` to metric list and document parameters
- show new metric ID and output in example script and docs
- explain per-model scores, token counts, and skipping long inputs

## Testing
- `pre-commit run --files docs/DEVELOPING_VALIDATION_METRICS.md docs/RESULTS.md docs/cli_reference.md examples/collect_engine_metrics.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845a1a82e5c8329b34607f4a1af2855