### PR TITLE
Add multi-model embedding similarity metric

### DIFF
--- a/src/compact_memory/validation/__init__.py
+++ b/src/compact_memory/validation/__init__.py
@@ -27,11 +27,17 @@ else:
     ]
 
 try:  # embedding dependencies may be missing
-    from .embedding_metrics import EmbeddingSimilarityMetric
+    from .embedding_metrics import (
+        EmbeddingSimilarityMetric,
+        MultiModelEmbeddingSimilarityMetric,
+    )
 except Exception:  # pragma: no cover - optional dependency may be missing
-    EmbeddingSimilarityMetric = None  # type: ignore
+    EmbeddingSimilarityMetric = MultiModelEmbeddingSimilarityMetric = None  # type: ignore
 else:
-    __all__ += ["EmbeddingSimilarityMetric"]
+    __all__ += [
+        "EmbeddingSimilarityMetric",
+        "MultiModelEmbeddingSimilarityMetric",
+    ]
 
 try:
     from .llm_judge_metric import LLMJudgeMetric

--- a/src/compact_memory/validation/embedding_metrics.py
+++ b/src/compact_memory/validation/embedding_metrics.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 """Embedding-based validation metrics."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 import numpy as np
+import logging
+
+from .. import token_utils
 
 from .. import embedding_pipeline as ep
 from .metrics_abc import ValidationMetric
@@ -51,4 +54,89 @@ register_validation_metric(
     EmbeddingSimilarityMetric.metric_id, EmbeddingSimilarityMetric
 )
 
-__all__ = ["EmbeddingSimilarityMetric"]
+
+class MultiModelEmbeddingSimilarityMetric(ValidationMetric):
+    """Compare text similarity across multiple embedding models."""
+
+    metric_id = "multi_model_embedding_similarity"
+
+    def __init__(self, model_names: Optional[List[str]] = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.model_names = model_names or ["sentence-transformers/all-MiniLM-L6-v2"]
+
+    def _get_tokenizer(self, model_name: str):
+        if model_name.startswith("openai/"):
+            base_name = model_name.split("/", 1)[1]
+            try:
+                import tiktoken
+
+                tok = tiktoken.encoding_for_model(base_name)
+            except Exception:
+                import tiktoken
+
+                tok = tiktoken.get_encoding("gpt2")
+            max_len = getattr(tok, "n_ctx", None)
+            setattr(tok, "model_max_length", max_len)
+            return tok
+        try:
+            from transformers import AutoTokenizer
+        except Exception:
+            from ..local_llm import AutoTokenizer  # pragma: no cover - fallback
+
+        return AutoTokenizer.from_pretrained(model_name)
+
+    def evaluate(
+        self,
+        *,
+        original_text: Optional[str] = None,
+        compressed_text: Optional[str] = None,
+        llm_response: Optional[str] = None,
+        reference_answer: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Dict[str, Dict[str, float]]]:
+        if original_text is not None and compressed_text is not None:
+            text_a, text_b = original_text, compressed_text
+        elif llm_response is not None and reference_answer is not None:
+            text_a, text_b = reference_answer, llm_response
+        else:
+            raise ValueError(
+                "MultiModelEmbeddingSimilarityMetric requires original/compressed texts or response/reference texts."
+            )
+
+        if not text_a or not text_b:
+            return {"embedding_similarity": {}}
+
+        results: Dict[str, Dict[str, float]] = {}
+        for name in self.model_names:
+            try:
+                tokenizer = self._get_tokenizer(name)
+            except Exception as exc:  # pragma: no cover - tokenizer load failure
+                logging.warning("Failed loading tokenizer for %s: %s", name, exc)
+                continue
+
+            max_len = getattr(tokenizer, "model_max_length", None)
+            if isinstance(max_len, int) and max_len > 0:
+                len_a = token_utils.token_count(tokenizer, text_a)
+                len_b = token_utils.token_count(tokenizer, text_b)
+                if len_a > max_len or len_b > max_len:
+                    logging.warning(
+                        "Input exceeds model_max_length for %s; skipping", name
+                    )
+                    continue
+
+            vecs = ep.embed_text([text_a, text_b], model_name=name)
+            similarity = float(np.dot(vecs[0], vecs[1]))
+            token_count_b = token_utils.token_count(tokenizer, text_b)
+            results[name] = {
+                "token_count": token_count_b,
+                "similarity": similarity,
+            }
+
+        return {"embedding_similarity": results}
+
+
+register_validation_metric(
+    MultiModelEmbeddingSimilarityMetric.metric_id, MultiModelEmbeddingSimilarityMetric
+)
+
+__all__ = ["EmbeddingSimilarityMetric", "MultiModelEmbeddingSimilarityMetric"]

--- a/tests/test_multi_model_embedding_similarity_metric.py
+++ b/tests/test_multi_model_embedding_similarity_metric.py
@@ -1,0 +1,19 @@
+import numpy as np
+from compact_memory.validation.embedding_metrics import (
+    MultiModelEmbeddingSimilarityMetric,
+)
+
+
+def test_multi_model_embedding_similarity_basic(patch_embedding_model):
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=["dummy-model"])
+    scores = metric.evaluate(original_text="hello", compressed_text="hello")
+    data = scores["embedding_similarity"]["dummy-model"]
+    assert np.isclose(data["similarity"], 1.0)
+    assert data["token_count"] == 1
+
+
+def test_multi_model_embedding_similarity_skip_long(patch_embedding_model):
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=["dummy-model"])
+    long_text = " ".join("t" + str(i) for i in range(200))
+    scores = metric.evaluate(original_text=long_text, compressed_text=long_text)
+    assert scores["embedding_similarity"] == {}


### PR DESCRIPTION
## Summary
- add `MultiModelEmbeddingSimilarityMetric` for comparing embeddings with several models
- register new metric in validation package
- test metric behaviour

## Testing
- `pre-commit run --files src/compact_memory/validation/embedding_metrics.py src/compact_memory/validation/__init__.py tests/test_multi_model_embedding_similarity_metric.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a1a668e883299e53927944487c59