### PR TITLE
Add multi-model embedding similarity metric tests

### DIFF
--- a/src/compact_memory/validation/__init__.py
+++ b/src/compact_memory/validation/__init__.py
@@ -27,11 +27,15 @@ else:
     ]
 
 try:  # embedding dependencies may be missing
-    from .embedding_metrics import EmbeddingSimilarityMetric
+    from .embedding_metrics import (
+        EmbeddingSimilarityMetric,
+        MultiEmbeddingSimilarityMetric,
+    )
 except Exception:  # pragma: no cover - optional dependency may be missing
     EmbeddingSimilarityMetric = None  # type: ignore
+    MultiEmbeddingSimilarityMetric = None  # type: ignore
 else:
-    __all__ += ["EmbeddingSimilarityMetric"]
+    __all__ += ["EmbeddingSimilarityMetric", "MultiEmbeddingSimilarityMetric"]
 
 try:
     from .llm_judge_metric import LLMJudgeMetric

--- a/src/compact_memory/validation/embedding_metrics.py
+++ b/src/compact_memory/validation/embedding_metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Embedding-based validation metrics."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 
@@ -47,8 +47,79 @@ class EmbeddingSimilarityMetric(ValidationMetric):
         return {"semantic_similarity": score}
 
 
+class MultiEmbeddingSimilarityMetric(ValidationMetric):
+    """Cosine similarity using multiple embedding models."""
+
+    metric_id = "embedding_similarity_multi"
+
+    def __init__(
+        self,
+        model_names: Sequence[str] | None = None,
+        max_tokens: int = 8192,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.model_names = list(model_names) if model_names else [ep._MODEL_NAME]
+        self.max_tokens = int(max_tokens)
+
+    def _token_count(self, a: str, b: str) -> int:
+        return len((a + " " + b).split())
+
+    def _max_allowed_tokens(self) -> int:
+        limit = self.max_tokens
+        for name in self.model_names:
+            try:
+                model = ep._load_model(name, self.config_params.get("device", "cpu"))
+                ml = getattr(model, "model_max_length", None)
+                if isinstance(ml, int):
+                    limit = min(limit, ml)
+            except Exception:
+                continue
+        return limit
+
+    def evaluate(
+        self,
+        *,
+        original_text: Optional[str] = None,
+        compressed_text: Optional[str] = None,
+        llm_response: Optional[str] = None,
+        reference_answer: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if original_text is not None and compressed_text is not None:
+            text_a, text_b = original_text, compressed_text
+        elif llm_response is not None and reference_answer is not None:
+            text_a, text_b = reference_answer, llm_response
+        else:
+            raise ValueError(
+                "MultiEmbeddingSimilarityMetric requires original/compressed texts or response/reference texts."
+            )
+
+        tokens = self._token_count(text_a, text_b)
+        if tokens > self._max_allowed_tokens():
+            return {"token_count": float(tokens)}
+
+        results: Dict[str, float] = {"token_count": float(tokens)}
+        scores = []
+        embed_kwargs = {}
+        for key in ["device", "batch_size"]:
+            if key in self.config_params:
+                embed_kwargs[key] = self.config_params[key]
+        for name in self.model_names:
+            vecs = ep.embed_text([text_a, text_b], model_name=name, **embed_kwargs)
+            s = float(np.dot(vecs[0], vecs[1]))
+            scores.append(s)
+            results[name] = s
+        results["semantic_similarity"] = float(np.mean(scores)) if scores else 0.0
+        return results
+
+
 register_validation_metric(
     EmbeddingSimilarityMetric.metric_id, EmbeddingSimilarityMetric
 )
 
-__all__ = ["EmbeddingSimilarityMetric"]
+register_validation_metric(
+    MultiEmbeddingSimilarityMetric.metric_id, MultiEmbeddingSimilarityMetric
+)
+
+__all__ = ["EmbeddingSimilarityMetric", "MultiEmbeddingSimilarityMetric"]

--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -16,7 +16,7 @@ def test_list_metrics(tmp_path: Path):
     result = runner.invoke(app, ["dev", "list-metrics"], env=_env(tmp_path))
     assert result.exit_code == 0
     assert "compression_ratio" in result.stdout
-    assert "embedding_similarity" in result.stdout
+    assert "embedding_similarity_multi" in result.stdout
 
 
 def test_evaluate_compression_cli(tmp_path: Path, patch_embedding_model):
@@ -28,12 +28,15 @@ def test_evaluate_compression_cli(tmp_path: Path, patch_embedding_model):
             "hello",
             "hello",
             "--metric",
-            "embedding_similarity",
+            "embedding_similarity_multi",
+            "--metric-params",
+            '{"model_names": ["model_a", "model_b"]}',
         ],
         env=_env(tmp_path),
     )
     assert result.exit_code == 0
     assert "semantic_similarity" in result.stdout
+    assert "token_count" in result.stdout
 
 
 def test_evaluate_llm_response_cli(tmp_path: Path):

--- a/tests/test_embedding_similarity_metric.py
+++ b/tests/test_embedding_similarity_metric.py
@@ -1,5 +1,8 @@
 import numpy as np
-from compact_memory.validation.embedding_metrics import EmbeddingSimilarityMetric
+from compact_memory.validation.embedding_metrics import (
+    EmbeddingSimilarityMetric,
+    MultiEmbeddingSimilarityMetric,
+)
 
 
 def test_embedding_similarity_identical(patch_embedding_model):
@@ -12,3 +15,39 @@ def test_embedding_similarity_different(patch_embedding_model):
     metric = EmbeddingSimilarityMetric()
     scores = metric.evaluate(original_text="hello", compressed_text="world")
     assert scores["semantic_similarity"] < 1.0
+
+
+def test_multi_similarity_returns_per_model_scores(patch_embedding_model, monkeypatch):
+    import compact_memory.embedding_pipeline as ep
+
+    enc_a = ep.MockEncoder()
+    enc_b = ep.MockEncoder()
+
+    def fake_load(name: str, device: str):
+        return {"model_a": enc_a, "model_b": enc_b}[name]
+
+    monkeypatch.setattr(ep, "_load_model", fake_load)
+    metric = MultiEmbeddingSimilarityMetric(model_names=["model_a", "model_b"])
+    scores = metric.evaluate(original_text="hello", compressed_text="hello")
+    assert set(scores) == {
+        "semantic_similarity",
+        "model_a",
+        "model_b",
+        "token_count",
+    }
+    assert scores["token_count"] > 0
+    assert np.isclose(scores["semantic_similarity"], 1.0)
+
+
+def test_multi_similarity_skips_when_too_long(patch_embedding_model, monkeypatch):
+    import compact_memory.embedding_pipeline as ep
+
+    class SmallEncoder(ep.MockEncoder):
+        model_max_length = 2
+
+    monkeypatch.setattr(ep, "_load_model", lambda *a, **k: SmallEncoder())
+    metric = MultiEmbeddingSimilarityMetric(model_names=["small"], max_tokens=10)
+    text = "one two three four"
+    scores = metric.evaluate(original_text=text, compressed_text=text)
+    assert list(scores) == ["token_count"]
+    assert scores["token_count"] > SmallEncoder.model_max_length


### PR DESCRIPTION
## Summary
- add `MultiEmbeddingSimilarityMetric` implementation
- expose new metric from validation package
- update embedding similarity tests for multi-model metric
- extend CLI tests for new metric output

## Testing
- `pre-commit run --files src/compact_memory/validation/embedding_metrics.py src/compact_memory/validation/__init__.py tests/test_cli_metrics.py tests/test_embedding_similarity_metric.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a46ecbc483298756bfdd1dd45213