### PR TITLE
Fix duplicate import in tests

### DIFF
--- a/tests/test_stopword_pruner_engine.py
+++ b/tests/test_stopword_pruner_engine.py
@@ -1,5 +1,6 @@
 from compact_memory.engines.stopword_pruner_engine import StopwordPrunerEngine
-import nltk # For checking NLTK's list in the test if needed for clarity, though engine handles it.
+import nltk  # For checking NLTK's list in the test if needed for clarity, though engine handles it.
+
 
 def test_stopword_pruner_basic():
     engine = StopwordPrunerEngine()
@@ -12,29 +13,40 @@ def test_stopword_pruner_basic():
     out = compressed.text.lower()
 
     # Check specific words are removed or kept, accounting for NLTK's list
-    assert "actually" not in out, f"'actually' (filler) should be removed, output: {out}"
+    assert (
+        "actually" not in out
+    ), f"'actually' (filler) should be removed, output: {out}"
     assert "is" not in out.split(), f"'is' (stopword) should be removed, output: {out}"
-    assert "this" not in out.split(), f"'this' (stopword) should be removed, output: {out}"
+    assert (
+        "this" not in out.split()
+    ), f"'this' (stopword) should be removed, output: {out}"
     assert "a" not in out.split(), f"'a' (stopword) should be removed, output: {out}"
-    assert "you" not in out.split(), f"'you' (stopword by spaCy) should be removed, output: {out}"
+    assert (
+        "you" not in out.split()
+    ), f"'you' (stopword by spaCy) should be removed, output: {out}"
 
     # "very" and "just" are stopwords in NLTK's default English list
     # and the engine uses NLTK list if token.is_stop is False.
-    assert "very" not in out.split(), f"'very' (stopword by NLTK) should be removed, output: {out}"
-    assert "just" not in out.split(), f"'just' (stopword by NLTK) should be removed, output: {out}"
+    assert (
+        "very" not in out.split()
+    ), f"'very' (stopword by NLTK) should be removed, output: {out}"
+    assert (
+        "just" not in out.split()
+    ), f"'just' (stopword by NLTK) should be removed, output: {out}"
 
     assert "know" in out, f"'know' should be present, output: {out}"
     assert "simple" in out, f"'simple' should be present, output: {out}"
     assert "example" in out, f"'example' should be present, output: {out}"
     assert "test" in out, f"'test' should be present, output: {out}"
 
-
     # Check punctuation removal
     assert "," not in out, f"',' should be removed, output: {out}"
     assert "." not in out, f"'.' (from 'test.') should be removed, output: {out}"
 
     # Assert final output string based on expected token processing with NLTK stopwords
-    assert out == "simple example know test", f"Output string mismatch. Expected 'simple example know test', got '{out}'"
+    assert (
+        out == "simple example know test"
+    ), f"Output string mismatch. Expected 'simple example know test', got '{out}'"
 
     assert trace.engine_name == "stopword_pruner", "Trace engine name mismatch"
 
@@ -51,17 +63,25 @@ def test_stopword_pruner_basic():
     # using spaCy 'en_core_web_sm' AND NLTK's English stopwords:
     # Stopwords: "This"(spaCy), "is"(spaCy), "a"(spaCy), "very"(NLTK), "you"(spaCy), "just"(NLTK), "a"(spaCy) (7)
     # Fillers: "actually" (1)
-    assert removed_stopwords_count == 7, f"Expected 7 stopwords removed, got {removed_stopwords_count}. Trace steps: {trace.steps}"
-    assert removed_fillers_count == 1, f"Expected 1 filler removed, got {removed_fillers_count}. Trace steps: {trace.steps}"
+    assert (
+        removed_stopwords_count == 7
+    ), f"Expected 7 stopwords removed, got {removed_stopwords_count}. Trace steps: {trace.steps}"
+    assert (
+        removed_fillers_count == 1
+    ), f"Expected 1 filler removed, got {removed_fillers_count}. Trace steps: {trace.steps}"
+
 
 def test_stopword_pruner_budget_respected():
     engine = StopwordPrunerEngine()
     text = "word " * 30
     compressed, _ = engine.compress(text, llm_token_budget=5)
     output_tokens = compressed.text.split()
-    assert len(output_tokens) <= 5, f"Expected <= 5 tokens, got {len(output_tokens)}: '{compressed.text}'"
+    assert (
+        len(output_tokens) <= 5
+    ), f"Expected <= 5 tokens, got {len(output_tokens)}: '{compressed.text}'"
     for token in output_tokens:
         assert token == "word", f"Expected token 'word', got '{token}'"
+
 
 def test_stopword_pruner_min_word_length():
     engine = StopwordPrunerEngine(config={"min_word_length": 4})
@@ -74,7 +94,9 @@ def test_stopword_pruner_min_word_length():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "fast tree", f"Output string mismatch. Expected 'fast tree', got '{out}'"
+    assert (
+        out == "fast tree"
+    ), f"Output string mismatch. Expected 'fast tree', got '{out}'"
 
     removed_short_count = 0
     removed_stopwords_count = 0
@@ -84,11 +106,16 @@ def test_stopword_pruner_min_word_length():
         elif step["type"] == "remove_stopwords":
             removed_stopwords_count = step["removed"]
 
-    assert removed_short_count == 3, f"Expected 3 short words removed, got {removed_short_count}. Trace: {trace.steps}"
+    assert (
+        removed_short_count == 3
+    ), f"Expected 3 short words removed, got {removed_short_count}. Trace: {trace.steps}"
     # "A" is a stopword by spaCy. "to", "the" are also typical stopwords.
     # NLTK's list is also active in the engine's logic.
     # "A" (spaCy stop), "to" (spaCy stop), "the" (spaCy stop)
-    assert removed_stopwords_count == 3, f"Expected 3 stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 3
+    ), f"Expected 3 stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_remove_fillers_false():
     engine = StopwordPrunerEngine(config={"remove_fillers": False})
@@ -102,7 +129,9 @@ def test_stopword_pruner_remove_fillers_false():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "like test um", f"Output string mismatch. Expected 'like test um', got '{out}'"
+    assert (
+        out == "like test um"
+    ), f"Output string mismatch. Expected 'like test um', got '{out}'"
 
     removed_fillers_count = 0
     removed_stopwords_count = 0
@@ -112,8 +141,13 @@ def test_stopword_pruner_remove_fillers_false():
         elif step["type"] == "remove_stopwords":
             removed_stopwords_count = step["removed"]
 
-    assert removed_fillers_count == 0, f"Expected 0 fillers removed, got {removed_fillers_count}. Trace: {trace.steps}"
-    assert removed_stopwords_count == 5, f"Expected 5 stopwords removed (This, is, a, to, see), got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_fillers_count == 0
+    ), f"Expected 0 fillers removed, got {removed_fillers_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 5
+    ), f"Expected 5 stopwords removed (This, is, a, to, see), got {removed_stopwords_count}. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_remove_duplicate_words_true():
     engine = StopwordPrunerEngine(config={"remove_duplicates": True})
@@ -136,7 +170,9 @@ def test_stopword_pruner_remove_duplicate_words_true():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "yes agree", f"Output string mismatch. Expected 'yes agree', got '{out}'"
+    assert (
+        out == "yes agree"
+    ), f"Output string mismatch. Expected 'yes agree', got '{out}'"
 
     removed_duplicates_count = 0
     removed_stopwords_count = 0
@@ -146,11 +182,18 @@ def test_stopword_pruner_remove_duplicate_words_true():
         elif step["type"] == "remove_stopwords":
             removed_stopwords_count = step["removed"]
 
-    assert removed_duplicates_count == 2, f"Expected 2 duplicate words removed, got {removed_duplicates_count}. Trace: {trace.steps}"
-    assert removed_stopwords_count == 5, f"Expected 5 stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_duplicates_count == 2
+    ), f"Expected 2 duplicate words removed, got {removed_duplicates_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 5
+    ), f"Expected 5 stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_remove_duplicate_sentences_true():
-    engine = StopwordPrunerEngine(config={"remove_duplicates": True, "min_word_length": 1})
+    engine = StopwordPrunerEngine(
+        config={"remove_duplicates": True, "min_word_length": 1}
+    )
     text = "Sentence one. Sentence two. Sentence one."
     # Expected processing:
     # Sent 1: "Sentence" (keep), "one" (stopword by spaCy, remove). prev_token_lower = "sentence".
@@ -162,7 +205,9 @@ def test_stopword_pruner_remove_duplicate_sentences_true():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "sentence", f"Output string mismatch. Expected 'sentence', got '{out}'"
+    assert (
+        out == "sentence"
+    ), f"Output string mismatch. Expected 'sentence', got '{out}'"
 
     removed_duplicates_count = 0
     removed_stopwords_count = 0
@@ -176,13 +221,20 @@ def test_stopword_pruner_remove_duplicate_sentences_true():
     # 1. Word "Sentence" from "Sentence two." (prev was "Sentence" from "Sentence one.")
     # 2. Tokens "Sentence", "one", "." from the third sentence ("Sentence one.") being a duplicate sentence, matched by _TOKEN_RE.
     # Total = 1 (word) + 3 (sentence tokens) = 4
-    assert removed_duplicates_count == 4, f"Expected 4 duplicate tokens removed (1 word, 3 from sent), got {removed_duplicates_count}. Trace: {trace.steps}"
+    assert (
+        removed_duplicates_count == 4
+    ), f"Expected 4 duplicate tokens removed (1 word, 3 from sent), got {removed_duplicates_count}. Trace: {trace.steps}"
     # Stopwords: "one" (from sent 1), "two" (from sent 2) - spaCy marks them as is_stop.
-    assert removed_stopwords_count == 2, f"Expected 2 stopwords removed ('one', 'two'), got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 2
+    ), f"Expected 2 stopwords removed ('one', 'two'), got {removed_stopwords_count}. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_remove_duplicates_false():
     # Test with explicit config, though remove_duplicates=False is default.
-    engine = StopwordPrunerEngine(config={"remove_duplicates": False, "min_word_length": 1})
+    engine = StopwordPrunerEngine(
+        config={"remove_duplicates": False, "min_word_length": 1}
+    )
     text = "A word word. A sentence. A sentence."
     # Expected:
     # "A" (stopword) -> removed (x3)
@@ -196,7 +248,9 @@ def test_stopword_pruner_remove_duplicates_false():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "word word sentence sentence", f"Output string mismatch. Expected 'word word sentence sentence', got '{out}'"
+    assert (
+        out == "word word sentence sentence"
+    ), f"Output string mismatch. Expected 'word word sentence sentence', got '{out}'"
 
     removed_duplicates_count = 0
     removed_stopwords_count = 0
@@ -206,15 +260,22 @@ def test_stopword_pruner_remove_duplicates_false():
         elif step["type"] == "remove_stopwords":
             removed_stopwords_count = step["removed"]
 
-    assert removed_duplicates_count == 0, f"Expected 0 duplicate words/sentences removed, got {removed_duplicates_count}. Trace: {trace.steps}"
-    assert removed_stopwords_count == 3, f"Expected 3 stopwords removed (the three 'A's), got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_duplicates_count == 0
+    ), f"Expected 0 duplicate words/sentences removed, got {removed_duplicates_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 3
+    ), f"Expected 3 stopwords removed (the three 'A's), got {removed_stopwords_count}. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_preserve_order_false():
-    engine = StopwordPrunerEngine(config={
-        "preserve_order": False,
-        "min_word_length": 1,
-        "remove_duplicates": False # Explicitly show preserve_order=False makes unique
-    })
+    engine = StopwordPrunerEngine(
+        config={
+            "preserve_order": False,
+            "min_word_length": 1,
+            "remove_duplicates": False,  # Explicitly show preserve_order=False makes unique
+        }
+    )
     text = "zebra alpha charlie bravo alpha"
     # No stopwords in this text.
     # output_tokens before sort: ["zebra", "alpha", "charlie", "bravo", "alpha"] (if remove_duplicates=False)
@@ -224,57 +285,76 @@ def test_stopword_pruner_preserve_order_false():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "alpha bravo charlie zebra",         f"Output string mismatch. Expected 'alpha bravo charlie zebra', got '{out}'"
+    assert (
+        out == "alpha bravo charlie zebra"
+    ), f"Output string mismatch. Expected 'alpha bravo charlie zebra', got '{out}'"
     # Verify no other removals happened unexpectedly
     for step_type in ["stopwords", "fillers", "short", "duplicates"]:
         removed_count = 0
         for step in trace.steps:
             if step["type"] == f"remove_{step_type}":
                 removed_count = step["removed"]
-        assert removed_count == 0, f"Expected 0 {step_type} removed, got {removed_count} for '{text}'. Trace: {trace.steps}"
+        assert (
+            removed_count == 0
+        ), f"Expected 0 {step_type} removed, got {removed_count} for '{text}'. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_preserve_order_true_maintains_order():
-    engine = StopwordPrunerEngine(config={
-        "preserve_order": True,
-        "remove_duplicates": False, # Test with duplicates present
-        "min_word_length": 1
-    })
+    engine = StopwordPrunerEngine(
+        config={
+            "preserve_order": True,
+            "remove_duplicates": False,  # Test with duplicates present
+            "min_word_length": 1,
+        }
+    )
     text = "zebra alpha charlie bravo alpha"
     # Expected: all tokens kept in original order.
 
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "zebra alpha charlie bravo alpha",         f"Output string mismatch. Expected 'zebra alpha charlie bravo alpha', got '{out}'"
+    assert (
+        out == "zebra alpha charlie bravo alpha"
+    ), f"Output string mismatch. Expected 'zebra alpha charlie bravo alpha', got '{out}'"
     # Verify no other removals happened unexpectedly
-    for step_type in ["stopwords", "fillers", "short", "duplicates"]: # duplicates should be 0 here by config
+    for step_type in [
+        "stopwords",
+        "fillers",
+        "short",
+        "duplicates",
+    ]:  # duplicates should be 0 here by config
         removed_count = 0
         for step in trace.steps:
             if step["type"] == f"remove_{step_type}":
                 removed_count = step["removed"]
-        assert removed_count == 0, f"Expected 0 {step_type} removed, got {removed_count} for '{text}'. Trace: {trace.steps}"
+        assert (
+            removed_count == 0
+        ), f"Expected 0 {step_type} removed, got {removed_count} for '{text}'. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_language_spanish():
     # First, ensure NLTK has Spanish stopwords list.
     # This is a check that the test environment is as expected.
-    import nltk
+
     try:
         nltk.corpus.stopwords.words("spanish")
-    except OSError: # OSError if 'stopwords' corpus not found or language missing
-        nltk.download('stopwords', quiet=True) # Attempt download
+    except OSError:  # OSError if 'stopwords' corpus not found or language missing
+        nltk.download("stopwords", quiet=True)  # Attempt download
         # If it still fails, this test might not be able to run correctly,
         # but the engine itself has a fallback. For this test, we want to see NLTK Spanish work.
         # Re-check after download attempt.
         try:
             nltk.corpus.stopwords.words("spanish")
-        except Exception as e:
+        except Exception:
             # If spanish stopwords are truly unavailable after download attempt,
             # this specific test for Spanish cannot pass as intended.
             # We could skip or expect fallback, but plan is to test Spanish.
             # For now, assume it will be available in a well-set-up test env.
-            pass # Let it proceed, engine might fallback.
+            pass  # Let it proceed, engine might fallback.
 
-    engine = StopwordPrunerEngine(config={"stopwords_language": "spanish", "min_word_length": 1})
+    engine = StopwordPrunerEngine(
+        config={"stopwords_language": "spanish", "min_word_length": 1}
+    )
     text = "el perro come una manzana"
     # "el" and "una" are common Spanish stopwords.
     # "perro", "come", "manzana" are not.
@@ -284,14 +364,19 @@ def test_stopword_pruner_language_spanish():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "perro come manzana",         f"Output string mismatch. Expected 'perro come manzana', got '{out}'"
+    assert (
+        out == "perro come manzana"
+    ), f"Output string mismatch. Expected 'perro come manzana', got '{out}'"
 
     removed_stopwords_count = 0
     for step in trace.steps:
         if step["type"] == "remove_stopwords":
             removed_stopwords_count = step["removed"]
 
-    assert removed_stopwords_count == 2,         f"Expected 2 Spanish stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 2
+    ), f"Expected 2 Spanish stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+
 
 def test_stopword_pruner_punctuation_whitespace():
     engine = StopwordPrunerEngine(config={"min_word_length": 1})
@@ -306,7 +391,9 @@ def test_stopword_pruner_punctuation_whitespace():
     compressed, trace = engine.compress(text, llm_token_budget=100)
     out = compressed.text.lower()
 
-    assert out == "hello world end",         f"Output string mismatch. Expected 'hello world end', got '{out}'"
+    assert (
+        out == "hello world end"
+    ), f"Output string mismatch. Expected 'hello world end', got '{out}'"
 
     removed_stopwords_count = 0
     removed_fillers_count = 0
@@ -323,7 +410,15 @@ def test_stopword_pruner_punctuation_whitespace():
         elif step["type"] == "remove_duplicates":
             removed_duplicates_count = step["removed"]
 
-    assert removed_stopwords_count == 3,         f"Expected 3 stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
-    assert removed_fillers_count == 0,         f"Expected 0 fillers removed, got {removed_fillers_count}. Trace: {trace.steps}"
-    assert removed_short_count == 0,         f"Expected 0 short words removed, got {removed_short_count}. Trace: {trace.steps}"
-    assert removed_duplicates_count == 0,         f"Expected 0 duplicates removed, got {removed_duplicates_count}. Trace: {trace.steps}"
+    assert (
+        removed_stopwords_count == 3
+    ), f"Expected 3 stopwords removed, got {removed_stopwords_count}. Trace: {trace.steps}"
+    assert (
+        removed_fillers_count == 0
+    ), f"Expected 0 fillers removed, got {removed_fillers_count}. Trace: {trace.steps}"
+    assert (
+        removed_short_count == 0
+    ), f"Expected 0 short words removed, got {removed_short_count}. Trace: {trace.steps}"
+    assert (
+        removed_duplicates_count == 0
+    ), f"Expected 0 duplicates removed, got {removed_duplicates_count}. Trace: {trace.steps}"


### PR DESCRIPTION
## Summary
- remove redundant `nltk` import in `test_stopword_pruner_engine`
- satisfy flake8 by eliminating unused variable

## Testing
- `pre-commit run --files tests/test_stopword_pruner_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845bb2f01dc83299e182b0249334861