### PR TITLE
Fix setup to install heavy deps

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -32,4 +32,8 @@ pip3 install nltk pre-commit
 # CLI dependencies that may not be declared in requirements.txt
 # (rich and typer are already installed above)
 
+# Heavy optional dependencies needed for evaluations and local model examples
+pip3 install torch sentence-transformers transformers spacy \
+    google-generativeai evaluate
+
 


### PR DESCRIPTION
## Summary
- install heavy evaluation dependencies via `.codex/setup.sh`

## Testing
- `pre-commit run --files .codex/setup.sh`
- `pytest -q` *(fails: test_stopword_pruner_remove_fillers_false, test_stopword_pruner_remove_duplicate_sentences_true)*

------
https://chatgpt.com/codex/tasks/task_e_6845caa596508329b682e72672a32213