### PR TITLE
Lazy load plugins to avoid import cycles

### DIFF
--- a/src/compact_memory/engines/__init__.py
+++ b/src/compact_memory/engines/__init__.py
@@ -11,11 +11,9 @@ from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
 
 # Import registry functions
 from .registry import get_compression_engine
-from compact_memory.plugin_loader import load_plugins
 
-
-# Load plugins (including any built-in engines registered via entry points)
-load_plugins()
+# Plugin loading is deferred to avoid circular imports. ``registry`` functions
+# ensure ``load_plugins`` is called before engine classes are requested.
 
 
 def load_engine(path: str | os.PathLike) -> BaseCompressionEngine:

--- a/src/compact_memory/engines/registry.py
+++ b/src/compact_memory/engines/registry.py
@@ -17,6 +17,13 @@ _ENGINE_REGISTRY: Dict[str, Type["BaseCompressionEngine"]] = (
 _ENGINE_INFO: Dict[str, Dict[str, Optional[str]]] = {}
 
 
+def _ensure_plugins_loaded() -> None:
+    """Load plugins if they have not been loaded yet."""
+    from compact_memory.plugin_loader import load_plugins
+
+    load_plugins()
+
+
 def register_compression_engine(
     id: str,
     cls: Type["BaseCompressionEngine"],  # Use string literal
@@ -47,14 +54,17 @@ def get_compression_engine(
     id: str,
 ) -> Type["BaseCompressionEngine"]:  # Use string literal
     """Return the engine class registered under ``id``."""
+    _ensure_plugins_loaded()
     return _ENGINE_REGISTRY[id]
 
 
 def available_engines() -> List[str]:
+    _ensure_plugins_loaded()
     return sorted(_ENGINE_REGISTRY)
 
 
 def get_engine_metadata(id: str) -> Dict[str, Optional[str]] | None:
+    _ensure_plugins_loaded()
     info = _ENGINE_INFO.get(id)
     if info:
         info_with_id = info.copy()
@@ -64,6 +74,7 @@ def get_engine_metadata(id: str) -> Dict[str, Optional[str]] | None:
 
 
 def all_engine_metadata() -> Dict[str, Dict[str, Optional[str]]]:
+    _ensure_plugins_loaded()
     return dict(_ENGINE_INFO)
 
 


### PR DESCRIPTION
## Summary
- defer engine plugin loading until registry functions are used
- remove eager plugin loading from `compact_memory.engines`

## Testing
- `pre-commit run --files src/compact_memory/engines/__init__.py src/compact_memory/engines/registry.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684609b36e0c832982bb00f938d50686