### PR TITLE
I've corrected some command-line arguments and engine names in the `c…

### DIFF
--- a/examples/compact_memory_user_guide.ipynb
+++ b/examples/compact_memory_user_guide.ipynb
@@ -206,7 +206,7 @@
     "\n",
     "The `compress` command lets you apply a compression engine to various forms of input: a direct line of text (using `--text`), or a single file or an entire directory (by providing the path as a positional argument). The following subsections will demonstrate these use cases.\n",
     "\n",
-    "The CLI uses strategies that are built into `compact-memory` (e.g., `prototype`, `pipeline`, `none`, `first_last`). For these examples, we'll use some of these built-in strategies."
+    "The CLI uses strategies that are built into `compact-memory` (e.g., `pipeline`, `none`, `first_last`, `read_agent_gist`, `stopword_pruner`). For these examples, we'll use some of these built-in strategies. (Note: The 'prototype' engine was mentioned in a previous version of this guide but is not available in the current CLI; 'first_last' is used in its place in the examples below.)"
    ],
    "metadata": {}
   },
@@ -216,16 +216,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Example: Compress a short text string using the 'prototype' engine\n",
+    "# Example: Compress a short text string using the 'first_last' engine (Note: 'prototype' was previously mentioned but is not available in this environment)\n",
     "# This command demonstrates compressing a simple line of text. \n",
-    "# We use the 'prototype' engine, fitting it within a 20-token budget.\n",
-    "!compact-memory compress --engine prototype --text \"This is a fairly long sentence that we want to compress using the command line interface to a small number of tokens.\" --budget 20\n",
+    "# We use the 'first_last' engine, fitting it within a 20-token budget.\n",
+    "!compact-memory compress --engine first_last --text \"This is a fairly long sentence that we want to compress using the command line interface to a small number of tokens.\" --budget 20\n",
     "\n",
-    "# Example: Compress a text file using the 'prototype' engine\n",
+    "# Example: Compress a text file using the 'first_last' engine (Note: 'prototype' was previously mentioned but is not available in this environment)\n",
     "# This command demonstrates compressing an entire file. We use 'sample_data/moon_landing/full.txt'.\n",
-    "# The 'prototype' engine is employed to summarize the content within a 100-token budget.\n",
-    "# To compress a file, provide its path as an argument using --input-file. For instance:\n",
-    "!compact-memory compress --engine prototype --input-file sample_data/moon_landing/full.txt --budget 100"
+    "# The 'first_last' engine is employed to summarize the content within a 100-token budget.\n",
+    "# To compress a file, provide its path as an argument using --file. For instance:\n",
+    "!compact-memory compress --engine first_last --file sample_data/moon_landing/full.txt --budget 100"
    ]
   },
   {
@@ -245,12 +245,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Example: Compress an entire directory using the 'prototype' engine\n",
+    "# Example: Compress an entire directory using the 'first_last' engine (Note: 'prototype' was previously mentioned but is not available in this environment)\n",
     "# This command demonstrates compressing all supported files within a directory.\n",
     "# We use the 'sample_data/moon_landing' directory.\n",
-    "# The 'prototype' engine will be applied to each file.\n",
-    "# The `compress` command uses --input-dir for directory paths.\n",
-    "!compact-memory compress --engine prototype --input-dir sample_data/moon_landing --budget 200\n",
+    "# The 'first_last' engine will be applied to each file.\n",
+    "# The `compress` command uses --dir for directory paths.\n",
+    "!compact-memory compress --engine first_last --dir sample_data/moon_landing --budget 200\n",
     "# You might want to add --output some_directory_output.json if you want to inspect results later"
    ]
   },
@@ -260,14 +260,15 @@
    "source": [
     "#### Choosing a Engine with `--engine`\n",
     "\n",
-    "The `--engine` option is key to controlling how `compact-memory` compresses your text. Different strategies have different behaviors:\n",
+    "The `--engine` option is key to controlling how `compact-memory` compresses your text. Different strategies have different behaviors. The available one-shot engines currently include `first_last`, `none`, `pipeline`, `read_agent_gist`, and `stopword_pruner`.\n",
     "\n",
-    "*   **`prototype`**: Aims to create a compressed representation using a prototype-based approach. (Example used above).\n",
-    "*   **`pipeline`**: Allows chaining multiple processing steps (more advanced and requires specific configuration not covered in this basic example).\n",
+    "*   **`first_last`**: A simple engine that typically keeps the first and last parts of the text. (Used in examples above as a substitute for the previously mentioned 'prototype' engine).\n",
     "*   **`none`**: Passes through the text without compression (useful for baseline or token counting).\n",
-    "*   **`first_last`**: A simple engine that typically keeps the first and last parts of the text.\n",
+    "*   **`pipeline`**: Allows chaining multiple processing steps (more advanced and requires specific configuration not covered in this basic example).\n",
+    "*   **`read_agent_gist`**: Available engine.\n",
+    "*   **`stopword_pruner`**: Removes filler words and stopwords to minimize length while preserving key content.\n",
     "\n",
-    "You can switch between them easily. For example, to process our `full.txt` using `none` (no compression) instead of `prototype`:"
+    "You can switch between them easily. For example, to process our `full.txt` using `none` (no compression) instead of `first_last` (which replaced `prototype`):"
    ]
   },
   {
@@ -277,8 +278,8 @@
    "outputs": [],
    "source": [
     "# Example of using a different engine (none) on the full.txt file\n",
-    "# To process a file, provide its path as an argument using --input-file. For instance:\n",
-    "!compact-memory compress --engine none --input-file sample_data/moon_landing/full.txt --budget 100"
+    "# To process a file, provide its path as an argument using --file. For instance:\n",
+    "!compact-memory compress --engine none --file sample_data/moon_landing/full.txt --budget 100"
    ]
   },
   {


### PR DESCRIPTION
…ompact_memory_user_guide.ipynb` notebook for you.

Specifically, I've made these changes:
- Replaced the invalid `--input-file` argument with `--file`.
- Replaced the invalid `--input-dir` argument with `--dir`.
- Replaced the unavailable `--engine prototype` with `--engine first_last`.

I've also updated the Markdown descriptions and comments within the notebook to reflect these adjustments. This ensures everything is consistent and notes that 'first_last' is used as a substitute for the 'prototype' engine in examples because 'prototype' isn't currently available in the CLI.