### PR TITLE
feat: Consolidate directory compression output

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,8 +27,43 @@ cat notes.txt | compact-memory compress --text - --engine truncate --budget 20
 Write the output to a file with `-o`:
 
 ```bash
-compact-memory compress --file "path/to/your_document.txt" -s first_last -b 100 -o "path/to/compressed_output.txt"
+compact-memory compress --file "path/to/your_document.txt" --engine first_last --budget 100 -o "path/to/compressed_output.txt"
 ```
+
+### Compressing a Directory
+
+When you need to compress all text files within a directory (and optionally its subdirectories), `compact-memory` offers a directory compression mode.
+
+**Behavior:**
+
+*   All files matching the specified pattern (default: `*.txt`) within the input directory are read.
+*   If the `--recursive` (or `-r`) option is used, files in subdirectories are also included.
+*   The content of these files is **concatenated into a single body of text**.
+*   This combined text is then compressed using the chosen engine and budget.
+*   The result is a **single output file** named `compressed_output.txt`.
+
+**Output Path:**
+
+*   If you specify an `--output-dir`, the `compressed_output.txt` file will be saved in that directory.
+*   If no `--output-dir` is provided, `compressed_output.txt` will be saved directly within the input directory (`--dir`).
+*   The `--output` (or `-o`) option **cannot be used** with `--dir`.
+
+**Examples:**
+
+1.  Compress all `.txt` files in `path/to/your_text_files/` and save the result to `path/to/output_directory/compressed_output.txt`:
+
+    ```bash
+    compact-memory compress --dir "path/to/your_text_files/" --engine first_last --budget 200 --output-dir "path/to/output_directory/"
+    ```
+    *(Expected output: `path/to/output_directory/compressed_output.txt`)*
+
+2.  Compress all `.md` files recursively in `project_docs/` and save `compressed_output.txt` into `project_docs/`:
+
+    ```bash
+    compact-memory compress --dir "project_docs/" --pattern "*.md" --recursive --engine summarization_engine --budget 500
+    ```
+    *(Expected output: `project_docs/compressed_output.txt`)*
+
 
 ### Using Compressed Output in an LLM Prompt
 


### PR DESCRIPTION
Refactors directory compression to produce a single output file by concatenating all matched files before compression. This is more suitable for LLM use cases where a combined context is often preferred.

Changes include:

- Modified `_compress_directory_to_files` in `src/compact_memory/cli/compress_commands.py` to read and concatenate all matching files into a single string, then compress this string once. The output is saved to a single file named `compressed_output.txt`.
- Updated `compress_command` to reflect this:
    - Disallowed `--output-file` when `--dir` is used.
    - Clarified help messages for `--output-dir` and related options.
- Updated `docs/USAGE.md` to explain the new directory compression behavior and provide revised examples.
- Added new integration tests in `tests/test_cli_compress_integration.py` to verify the consolidated directory compression.
- Disabled old tests that covered the previous per-file directory compression behavior.