### PR TITLE
Fix: Handle PipelineEngine instantiation in evaluate-engines

### DIFF
--- a/src/compact_memory/cli/dev_commands.py
+++ b/src/compact_memory/cli/dev_commands.py
@@ -23,6 +23,7 @@ from compact_memory.engines.registry import (
     all_engine_metadata as cm_all_engine_metadata,  # Renamed
     get_compression_engine,
 )
+from compact_memory.engines.pipeline_engine import PipelineConfig
 from compact_memory.embedding_pipeline import get_embedding_dim
 
 # PrototypeEngine was removed
@@ -970,7 +971,10 @@ def evaluate_engines_command(
     results: dict[str, dict[str, float]] = {}
     for eid in engine_ids:
         EngineCls = get_compression_engine(eid)
-        engine_instance = EngineCls()
+        if eid == "pipeline":
+            engine_instance = EngineCls(PipelineConfig())
+        else:
+            engine_instance = EngineCls()
 
         result = engine_instance.compress(text_input, llm_token_budget=budget)
         compressed = result[0] if isinstance(result, tuple) else result


### PR DESCRIPTION
The `evaluate-engines` CLI command was attempting to instantiate `PipelineEngine` without the required `config_or_engines` argument, leading to a TypeError.

This commit modifies the command to instantiate `PipelineEngine` with an empty `PipelineConfig()` when the 'pipeline' engine is specified. This allows the command to run without error, treating the 'pipeline' engine in this context as an empty pipeline.

Additionally, a new test case `test_dev_evaluate_engines_pipeline_engine` has been added to `tests/test_cli_engine.py`. This test verifies:
- The `evaluate-engines` command runs successfully with the 'pipeline' engine.
- The compression ratio for an empty pipeline is 1.0.
- Embedding similarity scores (if computed) are also 1.0, as the output is identical to the input for an empty pipeline.