### PR TITLE
Refactor: Standardize compression engine output and enable chaining

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -5,11 +5,11 @@ This section provides a reference for the core public APIs of Compact Memory, pa
 The following classes and modules are fundamental when developing new compression engines.
 ### `compact_memory.engines.BaseCompressionEngine`
 The abstract base class for all compression engines. Developers must subclass this to create new engines.
-*   `Key methods: \`compress(self, text_or_chunks, llm_token_budget, **kwargs)\``
+*   `Key methods: \`compress(self, text: str, budget: int, previous_compression_result: Optional[CompressedMemory] = None, **kwargs) -> CompressedMemory\``
 *   `Key attributes: \`id\` (string identifier for the engine)`
 ### `compact_memory.engines.CompressedMemory`
 A data class that holds the output of a compression operation.
-*   `Key attributes: \`text\` (string, the compressed content), \`metadata\` (optional dictionary)`
+*   `Key attributes: \`text: str\`, \`engine_id: Optional[str]\`, \`engine_config: Optional[Dict[str, Any]]\`, \`trace: Optional[CompressionTrace]\`, \`metadata: Optional[Dict[str, Any]]\``
 ### `compact_memory.engines.CompressionTrace`
 A data class used to record the steps and metadata of a compression process. Essential for debugging and explainability.
 *   `Key attributes: \`engine_name\`, \`engine_params\`, \`input_summary\`, \`steps\` (list of dicts), \`output_summary\`, \`processing_ms\`, \`final_compressed_object_preview\``

--- a/docs/tutorials/02_building_a_simple_engine.md
+++ b/docs/tutorials/02_building_a_simple_engine.md
@@ -15,7 +15,7 @@ Our engine, \`FirstNSentencesEngine\`, will:
 ### 1. Define the Engine Class
 Create a Python file for your engine, for example, \`my_engines.py\`.
 ```python
-from typing import Union, List, Tuple, Any
+from typing import Union, List, Tuple, Any, Optional, Dict # Added Optional, Dict
 from compact_memory.engines import BaseCompressionEngine, CompressedMemory, CompressionTrace
 from compact_memory.token_utils import get_tokenizer, token_count
 
@@ -30,9 +30,12 @@ except ImportError:
 class FirstNSentencesEngine(BaseCompressionEngine):
     id: str = "first_n_sentences"
 
-    def __init__(self, num_sentences: int = 3):
-        super().__init__()
-        self.num_sentences_to_keep = num_sentences
+    def __init__(self, num_sentences: int = 3, config: Optional[Dict[str, Any]] = None):
+        # Ensure config is passed to super and num_sentences is part of it for persistence
+        effective_config = config.copy() if config else {}
+        effective_config.setdefault('num_sentences', num_sentences)
+        super().__init__(config=effective_config)
+        self.num_sentences_to_keep = int(self.config.get('num_sentences', num_sentences)) # Get from config
         print(f"FirstNSentencesEngine initialized to keep {self.num_sentences_to_keep} sentences.")
 
     def _split_into_sentences(self, text: str) -> List[str]:
@@ -44,15 +47,20 @@ class FirstNSentencesEngine(BaseCompressionEngine):
 
     def compress(
         self,
-        text_or_chunks: Union[str, List[str]],
-        llm_token_budget: int,
+        text: str, # Changed from text_or_chunks
+        budget: int, # Changed from llm_token_budget
+        previous_compression_result: Optional[CompressedMemory] = None, # Added
         **kwargs: Any,
-    ) -> Tuple[CompressedMemory, CompressionTrace]:
+    ) -> CompressedMemory: # Changed return type
         input_text: str
-        if isinstance(text_or_chunks, list):
-            input_text = " ".join(text_or_chunks)
-        else:
-            input_text = str(text_or_chunks)
+        # This engine operates on the input text directly or previous if specifically designed.
+        # For this example, it will use the `text` parameter.
+        # If previous_compression_result was to be used:
+        # if previous_compression_result:
+        #     input_text = previous_compression_result.text
+        # else:
+        #     input_text = text
+        input_text = text # Assuming text is a string as per new signature guidelines
 
         tokenizer = kwargs.get("tokenizer")
         tokenizer_for_budgeting = tokenizer if tokenizer else lambda t: t.split()
@@ -61,7 +69,7 @@ class FirstNSentencesEngine(BaseCompressionEngine):
 
         original_token_count_val = token_count(tokenizer_for_budgeting, input_text)
 
-        trace_steps = [{'type': 'input_processing', 'details': {'input_type': type(text_or_chunks).__name__, 'original_length': len(input_text), 'original_tokens': original_token_count_val, 'budget_type': 'tokens' if tokenizer else 'words (fallback)', 'requested_budget': llm_token_budget}}]
+        trace_steps = [{'type': 'input_processing', 'details': {'input_type': type(text).__name__, 'original_length': len(input_text), 'original_tokens': original_token_count_val, 'budget_type': 'tokens' if tokenizer else 'words (fallback)', 'requested_budget': budget}}]
         sentences = self._split_into_sentences(input_text)
         trace_steps.append({'type': 'sentence_splitting', 'details': {'num_sentences_found': len(sentences), 'method': 'spaCy' if nlp_spacy else 'newline split'}})
 
@@ -72,16 +80,33 @@ class FirstNSentencesEngine(BaseCompressionEngine):
             if i >= self.num_sentences_to_keep:
                 trace_steps.append({'type': 'selection_stopped', 'details': {'reason': f'Reached configured limit of {self.num_sentences_to_keep} sentences.', 'sentences_selected': sentences_taken}}); break
             sentence_token_count = token_count(tokenizer_for_budgeting, sentence)
-            if (current_tokens + sentence_token_count) <= llm_token_budget:
+            if (current_tokens + sentence_token_count) <= budget: # Use budget
                 selected_sentences.append(sentence); current_tokens += sentence_token_count; sentences_taken += 1
                 trace_steps.append({'type': 'sentence_selected', 'details': {'sentence_index': i, 'sentence_preview': sentence[:50] + '...', 'sentence_tokens': sentence_token_count, 'cumulative_tokens': current_tokens}})
             else:
-                trace_steps.append({'type': 'sentence_skipped_budget', 'details': {'sentence_index': i, 'sentence_preview': sentence[:50] + '...', 'sentence_tokens': sentence_token_count, 'reason': f'Adding sentence would exceed token budget ({current_tokens + sentence_token_count} > {llm_token_budget}).'}}); break
+                trace_steps.append({'type': 'sentence_skipped_budget', 'details': {'sentence_index': i, 'sentence_preview': sentence[:50] + '...', 'sentence_tokens': sentence_token_count, 'reason': f'Adding sentence would exceed token budget ({current_tokens + sentence_token_count} > {budget}).'}}); break
 
         compressed_text = " ".join(selected_sentences)
         final_token_count = token_count(tokenizer_for_budgeting, compressed_text)
-        trace = CompressionTrace(engine_name=self.id, engine_params={'num_sentences': self.num_sentences_to_keep}, input_summary={'original_tokens': original_token_count_val, 'num_input_sentences': len(sentences)}, steps=trace_steps, output_summary={'compressed_tokens': final_token_count, 'num_output_sentences': len(selected_sentences)}, processing_ms=0.0, final_compressed_object_preview=compressed_text[:70])
-        return CompressedMemory(text=compressed_text, metadata={'sentences_kept': len(selected_sentences)}), trace
+
+        current_trace = CompressionTrace( # Renamed to current_trace
+            engine_name=self.id,
+            # Use self.config for engine_params as it includes num_sentences
+            strategy_params={'budget': budget, **kwargs}, # Pass all relevant params to trace
+            input_summary={'original_tokens': original_token_count_val, 'num_input_sentences': len(sentences)},
+            steps=trace_steps,
+            output_summary={'compressed_tokens': final_token_count, 'num_output_sentences': len(selected_sentences)},
+            processing_ms=0.0, # Placeholder, actual timing would be better
+            final_compressed_object_preview=compressed_text[:70]
+        )
+
+        return CompressedMemory(
+            text=compressed_text,
+            engine_id=self.id,
+            engine_config=self.config, # Store the engine's configuration
+            trace=current_trace,      # Embed the trace
+            metadata={'sentences_kept': len(selected_sentences)}
+        )
 ```
 ### 2. Register and Test the Engine
 Now, let's test our new engine. You can do this in the same \`my_engines.py\` file or a separate test script.
@@ -97,32 +122,45 @@ if __name__ == "__main__":
     sample_text1 = "This is the first sentence. It provides an introduction.\nThis is the second sentence, offering more details.\nThis is a third sentence, which should be excluded by this configuration.\nAnd a fourth one, also to be excluded."
     try: test_tokenizer = get_tokenizer("gpt2")
     except ImportError: test_tokenizer = str.split
-    compressed_mem1, trace1 = engine_test1.compress(sample_text1, llm_token_budget=50, tokenizer=test_tokenizer)
+    result1 = engine_test1.compress(sample_text1, budget=50, tokenizer=test_tokenizer) # Use 'budget'
     print(f"Original Text:\n{sample_text1}")
-    print(f"Compressed Text (Target 2 sentences, Budget 50):\n{compressed_mem1.text}")
-    print(f"Tokens: {token_count(test_tokenizer, compressed_mem1.text)}")
-    print(f"Metadata: {compressed_mem1.metadata}")
+    print(f"Compressed Text (Target 2 sentences, Budget 50):\n{result1.text}")
+    print(f"Tokens: {token_count(test_tokenizer, result1.text)}")
+    print(f"Metadata: {result1.metadata}")
+    if result1.trace:
+        print(f"Trace engine: {result1.trace.engine_name}, Steps: {len(result1.trace.steps)}")
+
 
     print("\n--- Test Case 2: Budget Constraint ---")
     engine_test2 = FirstNSentencesEngine(num_sentences=5)
     sample_text2 = "Sentence one is short. Sentence two is also quite brief.\nSentence three is a bit longer and might push the budget.\nSentence four is definitely very long and elaborate, probably too much for a small budget.\nSentence five would be next if budget allows."
-    compressed_mem2, trace2 = engine_test2.compress(sample_text2, llm_token_budget=20, tokenizer=test_tokenizer)
+    result2 = engine_test2.compress(sample_text2, budget=20, tokenizer=test_tokenizer) # Use 'budget'
     print(f"Original Text:\n{sample_text2}")
-    print(f"Compressed Text (Target 5 sentences, Budget 20):\n{compressed_mem2.text}")
-    print(f"Tokens: {token_count(test_tokenizer, compressed_mem2.text)}")
-    print(f"Metadata: {compressed_mem2.metadata}")
+    print(f"Compressed Text (Target 5 sentences, Budget 20):\n{result2.text}")
+    print(f"Tokens: {token_count(test_tokenizer, result2.text)}")
+    print(f"Metadata: {result2.metadata}")
+    if result2.trace:
+        print(f"Trace engine: {result2.trace.engine_name}, Output tokens: {result2.trace.output_summary.get('compressed_tokens')}")
 
-    if nlp_spacy:
+
+    if nlp_spacy: # This part of the test logic needs to be careful about global nlp_spacy
         print("\n--- Test Case 3: No spaCy (Fallback Sentence Splitting) ---")
-        original_nlp_spacy = nlp_spacy; nlp_spacy = None # type: ignore
+        # To properly test this, FirstNSentencesEngine should take nlp_spacy as a param or have a method to disable it
+        # For simplicity of example, assuming a way to influence its nlp_spacy usage or test separately
+        # A better way for testability: pass nlp_spacy instance or a flag to __init__
+        # For this tutorial, we'll assume the global mock trick is for demonstration.
+        original_nlp_spacy_ref = FirstNSentencesEngine.__module__.__dict__.get('nlp_spacy')
+        FirstNSentencesEngine.__module__.__dict__['nlp_spacy'] = None # Risky global patch for demo
+
         engine_test3 = FirstNSentencesEngine(num_sentences=2)
         sample_text3 = "First line is a sentence.\nSecond line is another."
-        compressed_mem3, trace3 = engine_test3.compress(sample_text3, llm_token_budget=30, tokenizer=test_tokenizer)
+        result3 = engine_test3.compress(sample_text3, budget=30, tokenizer=test_tokenizer) # Use 'budget'
         print(f"Original Text:\n{sample_text3}")
-        print(f"Compressed Text (Fallback, Target 2 sentences, Budget 30):\n{compressed_mem3.text}")
-        print(f"Tokens: {token_count(test_tokenizer, compressed_mem3.text)}")
-        print(f"Metadata: {compressed_mem3.metadata}")
-        nlp_spacy = original_nlp_spacy
+        print(f"Compressed Text (Fallback, Target 2 sentences, Budget 30):\n{result3.text}")
+        print(f"Tokens: {token_count(test_tokenizer, result3.text)}")
+        print(f"Metadata: {result3.metadata}")
+
+        FirstNSentencesEngine.__module__.__dict__['nlp_spacy'] = original_nlp_spacy_ref # Restore
 ```
 Explanation of the Code:
 *   `FirstNSentencesEngine(BaseCompressionEngine)`: Inherits from the base `BaseCompressionEngine`.
@@ -153,7 +191,7 @@ from compact_memory import get_compression_engine
 try:
     EngineClass = get_compression_engine("first_n_sentences")
     # Instantiate with parameters
-    my_engine = EngineClass(num_sentences=2)
+        my_engine = EngineClass(num_sentences=2) # num_sentences is now part of config in __init__
 
     text_to_compress = "This is a full sentence. This is another sentence that provides context. This third sentence is important for details. A fourth sentence might be too much for the budget. The fifth and final sentence concludes the example."
 
@@ -163,15 +201,20 @@ try:
     except ImportError:
         tokenizer = str.split # Fallback
 
-    compressed_output, trace_output = my_engine.compress(
+        # Call compress, expecting a single CompressedMemory object
+        result_api = my_engine.compress(
         text_to_compress,
-        llm_token_budget=20, # Example budget
+            budget=20, # Example budget, use 'budget'
         tokenizer=tokenizer
     )
     print("\n--- API Usage Test ---")
-    print(f"Compressed Text: {compressed_output.text}")
-    print(f"Tokens: {token_count(tokenizer, compressed_output.text)}")
-    print(f"Trace: {trace_output.engine_name}, Steps: {len(trace_output.steps)}")
+        print(f"Compressed Text: {result_api.text}")
+        print(f"Tokens: {token_count(tokenizer, result_api.text)}")
+        if result_api.trace:
+            print(f"Trace: {result_api.trace.engine_name}, Steps: {len(result_api.trace.steps)}")
+        print(f"Engine ID from result: {result_api.engine_id}")
+        # print(f"Engine Config from result: {result_api.engine_config}")
+
 except KeyError:
     print("Engine 'first_n_sentences' not found. Ensure it's registered for API usage outside its defining script.")
 

--- a/src/compact_memory/engines/first_last_engine.py
+++ b/src/compact_memory/engines/first_last_engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Engine that keeps the first and last chunks of text."""
 
-from typing import List, Union, Any
+from typing import List, Union, Any, Optional
 
 from compact_memory.token_utils import tokenize_text
 
@@ -29,8 +29,9 @@ class FirstLastEngine(BaseCompressionEngine):
         llm_token_budget: int | None,
         *,
         tokenizer: Any = None,
+        previous_compression_result: Optional[CompressedMemory] = None,
         **kwargs: Any,
-    ) -> tuple[CompressedMemory, CompressionTrace]:
+    ) -> CompressedMemory:
         text = (
             text_or_chunks
             if isinstance(text_or_chunks, str)
@@ -77,7 +78,10 @@ class FirstLastEngine(BaseCompressionEngine):
             },
             final_compressed_object_preview=kept[:50],
         )
-        return compressed, trace
+        compressed.trace = trace
+        compressed.engine_id = self.id
+        compressed.engine_config = self.config
+        return compressed
 
 
 # register_compression_engine(FirstLastEngine.id, FirstLastEngine, source="contrib") # Removed, as it's now registered in engines/__init__.py

--- a/src/compact_memory/engines/no_compression_engine.py
+++ b/src/compact_memory/engines/no_compression_engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Simple no-op compression engine."""
 
-from typing import Any, List
+from typing import Any, List, Optional
 
 from compact_memory.token_utils import truncate_text
 
@@ -28,8 +28,9 @@ class NoCompressionEngine(BaseCompressionEngine):
         llm_token_budget: int | None,
         *,
         tokenizer: Any = None,
+        previous_compression_result: Optional[CompressedMemory] = None,
         **kwargs: Any,
-    ) -> tuple[CompressedMemory, CompressionTrace]:
+    ) -> CompressedMemory:
         tokenizer = tokenizer or _DEFAULT_TOKENIZER or (lambda t, **_: t.split())
         if isinstance(text_or_chunks, list):
             text = "\n".join(text_or_chunks)
@@ -44,7 +45,10 @@ class NoCompressionEngine(BaseCompressionEngine):
             input_summary={"input_length": len(text)},
             output_summary={"output_length": len(text)},
         )
-        return compressed, trace
+        compressed.trace = trace
+        compressed.engine_id = self.id
+        compressed.engine_config = self.config
+        return compressed
 
 
 __all__ = ["NoCompressionEngine"]

--- a/src/compact_memory/engines/pipeline_engine.py
+++ b/src/compact_memory/engines/pipeline_engine.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 """Pipeline compression engine for chaining multiple engines."""
 
-from dataclasses import dataclass, field
-from typing import List, Union, Any
+from dataclasses import dataclass, field, asdict
+from typing import List, Union, Any, Optional
 
 # Import base classes directly to avoid package-level registration
 from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
@@ -54,26 +54,104 @@ class PipelineEngine(BaseCompressionEngine):
 
     def compress(
         self,
-        text_or_chunks: Union[str, List[str]],
-        llm_token_budget: int,
+        text_or_chunks: Union[str, List[str]], # This is the original text for the first engine if no previous_compression_result
+        budget: int, # Renamed from llm_token_budget for consistency
+        previous_compression_result: Optional[CompressedMemory] = None,
         **kwargs: Any,
-    ) -> tuple[CompressedMemory, CompressionTrace]:
-        current = text_or_chunks
-        step_traces = []
-        for engine in self.engines:
-            compressed, trace = engine.compress(current, llm_token_budget, **kwargs)
-            step_traces.append({"strategy": engine.id, "trace": trace})
-            current = compressed.text
-        final = CompressedMemory(text=current)
+    ) -> CompressedMemory:
+        current_compressed_memory: Optional[CompressedMemory] = previous_compression_result
+        accumulated_traces: List[CompressionTrace] = []
+
+        # Determine the very original text for the pipeline's input summary
+        original_input_text = text_or_chunks
+        if isinstance(text_or_chunks, List):
+            original_input_text = " ".join(text_or_chunks)
+
+
+        for i, engine in enumerate(self.engines):
+            input_text_for_engine: str
+            prev_comp_result_for_engine: Optional[CompressedMemory] = None
+
+            if i == 0: # First engine
+                if current_compressed_memory is None: # No initial result provided to the pipeline
+                    input_text_for_engine = original_input_text
+                    prev_comp_result_for_engine = None # Explicitly
+                else: # Initial result WAS provided to the pipeline
+                    input_text_for_engine = current_compressed_memory.text
+                    prev_comp_result_for_engine = current_compressed_memory
+            else: # Subsequent engines
+                if current_compressed_memory is None:
+                    # This case should ideally not happen if engines always return CompressedMemory
+                    # Or handle as an error/empty input
+                    # For now, let's assume it means stop processing or pass empty string
+                    # This indicates a previous engine in the pipeline failed or returned None unexpectedly
+                    # For robustness, we could log a warning and break, or try to continue with empty text.
+                    # Let's assume for now that engines always return a valid CompressedMemory object.
+                    # If current_compressed_memory is None here, it means an engine didn't return an object.
+                    # This is a contract violation based on our new return types.
+                    # However, to be safe, let's consider if we should raise an error or skip.
+                    # For now, let's assume valid CompressedMemory objects are always passed.
+                    pass # Should not be reached if contracts are followed
+
+                input_text_for_engine = current_compressed_memory.text
+                prev_comp_result_for_engine = current_compressed_memory
+
+            # Call the current engine's compress method
+            current_compressed_memory = engine.compress(
+                input_text_for_engine,
+                budget, # Pass the budget along
+                previous_compression_result=prev_comp_result_for_engine,
+                **kwargs, # Pass other kwargs along
+            )
+
+            if current_compressed_memory and current_compressed_memory.trace:
+                accumulated_traces.append(current_compressed_memory.trace)
+
+        if current_compressed_memory is None:
+            # This would happen if self.engines is empty or an engine returned None.
+            # Create a default CompressedMemory if pipeline was empty or failed early.
+            # For an empty pipeline, what should be returned? Perhaps the input text uncompressed?
+            # Or an empty text with a trace indicating no operations?
+            # For now, let's assume self.engines is not empty and all engines return valid CompressedMemory.
+            # If it could be empty, we'd need to define behavior.
+            # If the loop didn't run (empty self.engines), current_compressed_memory would be the initial previous_compression_result
+            if previous_compression_result: # Pipeline was empty, but initial result provided
+                 current_compressed_memory = previous_compression_result
+            else: # Pipeline was empty AND no initial result
+                current_compressed_memory = CompressedMemory(
+                    text=original_input_text if isinstance(original_input_text, str) else "",
+                    metadata={"notes": "Pipeline was empty or no operations performed."}
+                )
+
+
+        # Prepare strategy_params for the pipeline's trace
+        pipeline_strategy_params = {"budget": budget, **kwargs}
+        if isinstance(self.config, PipelineConfig): # self.config is PipelineConfig
+            pipeline_strategy_params["engines"] = [asdict(engine_conf) for engine_conf in self.config.engines]
+        elif isinstance(self.config, dict): # self.config could be a dict if BaseCompressionEngine.__init__ was used
+             pipeline_strategy_params.update(self.config)
+
+
+        # Create the pipeline's overall trace
         pipeline_trace = CompressionTrace(
             engine_name=self.id,
-            strategy_params={},
-            input_summary={"num_steps": len(self.engines)},
-            steps=step_traces,
-            output_summary={"output_length": len(final.text)},
-            final_compressed_object_preview=final.text[:50],
+            strategy_params=pipeline_strategy_params,
+            input_summary={"original_length": len(original_input_text if isinstance(original_input_text, str) else "")},
+            steps=[asdict(trace) for trace in accumulated_traces], # Store sub-traces as dicts
+            output_summary={"compressed_length": len(current_compressed_memory.text)},
+            final_compressed_object_preview=current_compressed_memory.text[:50],
         )
-        return final, pipeline_trace
+
+        # Create the final CompressedMemory object for the pipeline
+        final_compressed_output = CompressedMemory(
+            text=current_compressed_memory.text,
+            engine_id=self.id,
+            engine_config=pipeline_strategy_params, # Or a cleaned version of self.config if preferred
+            trace=pipeline_trace,
+            metadata=current_compressed_memory.metadata, # Preserve metadata from the last engine
+        )
+
+        return final_compressed_output
 
 
 __all__ = ["EngineConfig", "PipelineConfig", "PipelineEngine"]

--- a/src/compact_memory/engines/stopword_pruner_engine.py
+++ b/src/compact_memory/engines/stopword_pruner_engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, Union
+from typing import Any, List, Union, Optional
 import re
 
 from compact_memory.token_utils import tokenize_text, truncate_text
@@ -48,8 +48,9 @@ class StopwordPrunerEngine(BaseCompressionEngine):
         llm_token_budget: int | None,
         *,
         tokenizer: Any = None,
+        previous_compression_result: Optional[CompressedMemory] = None,
         **kwargs: Any,
-    ) -> tuple[CompressedMemory, CompressionTrace]:
+    ) -> CompressedMemory:
         text = (
             text_or_chunks
             if isinstance(text_or_chunks, str)
@@ -162,7 +163,10 @@ class StopwordPrunerEngine(BaseCompressionEngine):
             },
             final_compressed_object_preview=compressed_text[:50],
         )
-        return compressed, trace
+        compressed.trace = trace
+        compressed.engine_id = self.id
+        compressed.engine_config = self.config
+        return compressed
 
 
 register_compression_engine(

--- a/tests/engines/test_pipeline_engine.py
+++ b/tests/engines/test_pipeline_engine.py
@@ -1,0 +1,300 @@
+import pytest
+from dataclasses import asdict
+
+from compact_memory.engines.pipeline_engine import (
+    PipelineEngine,
+    EngineConfig,
+    PipelineConfig,
+)
+from compact_memory.engines.base import (
+    BaseCompressionEngine,
+    CompressedMemory,
+    CompressionTrace,
+)
+from compact_memory.engines.no_compression_engine import NoCompressionEngine
+from compact_memory.engines.first_last_engine import FirstLastEngine
+from unittest import mock
+
+# --- Fixtures ---
+
+@pytest.fixture
+def no_op_engine_config() -> EngineConfig:
+    return EngineConfig(engine_name=NoCompressionEngine.id)
+
+@pytest.fixture
+def first_last_engine_config() -> EngineConfig:
+    return EngineConfig(engine_name=FirstLastEngine.id)
+
+@pytest.fixture
+def no_op_engine_instance() -> NoCompressionEngine:
+    return NoCompressionEngine()
+
+@pytest.fixture
+def first_last_engine_instance() -> FirstLastEngine:
+    # Mock the tokenizer for FirstLastEngine for deterministic behavior in tests
+    # This avoids dependency on tiktoken being installed or specific tokenization results.
+    fle = FirstLastEngine()
+    # Patching _DEFAULT_TOKENIZER within first_last_engine module directly
+    with mock.patch("compact_memory.engines.first_last_engine._DEFAULT_TOKENIZER", None):
+        # Further, ensure tokenize_text (used by FirstLastEngine) uses a simple split,
+        # and decode is a simple join for testing purposes.
+        # This requires careful patching of where FirstLastEngine gets its tokenizer for decode.
+        # The engine's compress method takes a 'tokenizer' kwarg which is used for decoding.
+        # The internal tokenization uses compact_memory.token_utils.tokenize_text.
+        pass # Mocking will be handled inside tests where specific tokenizer behavior is critical
+    return fle
+
+
+# --- Test Cases ---
+
+def test_pipeline_engine_empty_pipeline():
+    text = "Test with empty pipeline."
+    budget = 50
+
+    # Test 1: Empty pipeline, no previous_compression_result
+    empty_pipeline_config = PipelineConfig(engines=[])
+    empty_engine = PipelineEngine(config_or_engines=empty_pipeline_config)
+
+    result_empty_no_prev = empty_engine.compress(text, budget)
+
+    assert isinstance(result_empty_no_prev, CompressedMemory)
+    assert result_empty_no_prev.text == text # Should return original text
+    assert result_empty_no_prev.engine_id == PipelineEngine.id
+    assert result_empty_no_prev.engine_config is not None
+    # Convert PipelineConfig to dict for comparison if engine_config stores it that way
+    expected_config_dict = {"budget": budget, "engines": []} # Based on current implementation
+    assert result_empty_no_prev.engine_config.get("budget") == budget # Check some key aspect
+
+    assert isinstance(result_empty_no_prev.trace, CompressionTrace)
+    assert result_empty_no_prev.trace.engine_name == PipelineEngine.id
+    assert result_empty_no_prev.trace.input_summary == {"original_length": len(text)}
+    assert result_empty_no_prev.trace.output_summary == {"compressed_length": len(text)}
+    assert len(result_empty_no_prev.trace.steps) == 0
+    assert result_empty_no_prev.metadata == {"notes": "Pipeline was empty or no operations performed."}
+
+    # Test 2: Empty pipeline, with previous_compression_result
+    prev_text = "previous text"
+    prev_cm = CompressedMemory(text=prev_text, engine_id="prev", trace=CompressionTrace(engine_name="prev", strategy_params={}, input_summary={}, output_summary={}))
+    result_empty_with_prev = empty_engine.compress(text, budget, previous_compression_result=prev_cm)
+
+    assert isinstance(result_empty_with_prev, CompressedMemory)
+    assert result_empty_with_prev.text == prev_text # Should return previous compressed text
+    assert result_empty_with_prev.engine_id == PipelineEngine.id
+    # The trace should reflect the pipeline's operation (or lack thereof) on the *original* text for this call
+    assert result_empty_with_prev.trace.input_summary == {"original_length": len(text)}
+    assert result_empty_with_prev.trace.output_summary == {"compressed_length": len(prev_text)} # Output is from prev_cm
+    assert len(result_empty_with_prev.trace.steps) == 0
+    # Metadata should be from the prev_cm if the pipeline is empty and prev_cm is passed.
+    # Current implementation passes metadata from the *last actual engine run*.
+    # If pipeline is empty, current_compressed_memory becomes previous_compression_result.
+    assert result_empty_with_prev.metadata == prev_cm.metadata
+
+
+def test_pipeline_engine_single_engine(no_op_engine_config: EngineConfig, no_op_engine_instance: NoCompressionEngine):
+    text = "Test with single NoOp engine."
+    budget = 20 # NoOpEngine will truncate if text is longer and budget is smaller
+
+    pipeline_config = PipelineConfig(engines=[no_op_engine_config])
+    engine = PipelineEngine(config_or_engines=pipeline_config)
+
+    result = engine.compress(text, budget)
+
+    assert isinstance(result, CompressedMemory)
+    # NoOpEngine with budget might truncate. For this test, assume budget > len(text) or test truncation.
+    # Let's use a budget that ensures no truncation by NoOp for simplicity here if not testing truncation.
+    budget_no_truncate = len(text) + 10
+    result_no_trunc = engine.compress(text, budget_no_truncate)
+
+    assert result_no_trunc.text == text
+    assert result_no_trunc.engine_id == PipelineEngine.id
+
+    pipeline_config_dict = asdict(pipeline_config)
+    # The engine_config in CompressedMemory for pipeline also includes budget and other kwargs passed to compress.
+    # So, it's not just asdict(pipeline_config).
+    # Let's check a key part.
+    assert result_no_trunc.engine_config.get("engines")[0]["engine_name"] == no_op_engine_config.engine_name
+
+    assert isinstance(result_no_trunc.trace, CompressionTrace)
+    assert result_no_trunc.trace.engine_name == PipelineEngine.id
+    assert result_no_trunc.trace.input_summary == {"original_length": len(text)}
+    assert result_no_trunc.trace.output_summary == {"compressed_length": len(text)}
+    assert len(result_no_trunc.trace.steps) == 1
+
+    sub_trace_dict = result_no_trunc.trace.steps[0]
+    assert sub_trace_dict["engine_name"] == NoCompressionEngine.id
+    assert sub_trace_dict["strategy_params"] == {"llm_token_budget": budget_no_truncate} # As set by NoOpEngine's trace
+
+def test_pipeline_engine_multiple_engines(no_op_engine_config: EngineConfig, first_last_engine_config: EngineConfig):
+    text = "one two three four five six seven eight nine ten" # 10 words
+    budget_fle = 4 # For FirstLastEngine: keep first 2, last 2 words. -> "one two nine ten"
+
+    # Pipeline: NoOpEngine -> FirstLastEngine
+    # NoOpEngine with large budget won't change the text.
+    # FirstLastEngine will then process the original text.
+    pipeline_config = PipelineConfig(engines=[no_op_engine_config, first_last_engine_config])
+    engine = PipelineEngine(config_or_engines=pipeline_config)
+
+    # Mock tokenizer for FirstLastEngine part of the pipeline
+    # This is complex because the instance of FirstLastEngine is created inside PipelineEngine.
+    # We'd have to mock where get_compression_engine / EngineConfig.create instantiates it.
+    # Simpler: Rely on FirstLastEngine's fallback to split() if tiktoken is not available,
+    # or ensure tests for FirstLastEngine itself cover tokenizer variations.
+    # For this pipeline test, focus on data flow.
+    # We'll assume FirstLastEngine is configured/mocked to behave predictably (e.g. uses split())
+
+    # To make FirstLastEngine predictable without complex mocking here,
+    # we can instantiate it manually with a mocked/simple tokenizer and pass list of instances
+    mocked_fle = FirstLastEngine()
+
+    # We need to ensure the FirstLastEngine instance within the pipeline uses a mock tokenizer for decode.
+    # This is tricky. Let's assume it falls back to string split and join for this test for simplicity of setup.
+    # If _DEFAULT_TOKENIZER is None in first_last_engine.py, it uses split() for tokenization part.
+    # The decode part is `tokenizer.decode`. If we pass `tokenizer=str.split` to FLE.compress, it fails.
+    # The `tokenizer` param in FLE.compress is for the *decode* step.
+    # The tokenization part uses `compact_memory.token_utils.tokenize_text`
+
+    # For pipeline, it's easier to test if sub-engines are simple or have globally patched tokenizers.
+    # Let's assume the simple split/join for FLE for this test.
+
+    # Create instances for the pipeline
+    no_op_inst = NoCompressionEngine()
+
+    # For FirstLastEngine, we need its tokenizer to be mocked for predictable output
+    # Patching the _DEFAULT_TOKENIZER in the module FirstLastEngine uses
+    with mock.patch("compact_memory.engines.first_last_engine._DEFAULT_TOKENIZER", None), \
+         mock.patch("compact_memory.token_utils._DEFAULT_TOKENIZER", None): # also for token_utils
+
+        # Create FirstLastEngine instance *after* patching, so it picks up the mocked default
+        fle_inst = FirstLastEngine()
+
+        # Now create pipeline with instances
+        engine_instances = PipelineEngine(config_or_engines=[no_op_inst, fle_inst])
+
+        # The 'tokenizer' argument to engine.compress is for the sub-engines if they accept it.
+        # FirstLastEngine's compress accepts 'tokenizer' for its decode step.
+        # NoOpEngine's compress also accepts 'tokenizer'.
+        # PipelineEngine passes kwargs including 'tokenizer' to its sub-engines.
+
+        # Define a mock decode function to be passed as 'tokenizer' argument
+        def mock_decode_func(tokens): return " ".join(tokens)
+
+        result = engine_instances.compress(text, budget_fle, tokenizer=mock_decode_func)
+
+        assert isinstance(result, CompressedMemory)
+        expected_text_after_fle = "one two nine ten"
+        assert result.text == expected_text_after_fle
+        assert result.engine_id == PipelineEngine.id
+
+        assert isinstance(result.trace, CompressionTrace)
+        assert result.trace.engine_name == PipelineEngine.id
+        assert len(result.trace.steps) == 2
+
+        # Check NoOpEngine's trace (first step)
+        noop_trace_dict = result.trace.steps[0]
+        assert noop_trace_dict["engine_name"] == NoCompressionEngine.id
+        # NoOpEngine's output (which is input to FLE) should be the original text
+        # This is hard to check directly from trace dicts unless output is part of trace.
+        # We can check strategy_params.
+        assert noop_trace_dict["strategy_params"]["llm_token_budget"] == budget_fle # budget is passed along
+
+        # Check FirstLastEngine's trace (second step)
+        fle_trace_dict = result.trace.steps[1]
+        assert fle_trace_dict["engine_name"] == FirstLastEngine.id
+        assert fle_trace_dict["strategy_params"]["llm_token_budget"] == budget_fle
+        assert fle_trace_dict["input_summary"]["input_tokens"] == 10 # "one two three four five six seven eight nine ten"
+        assert fle_trace_dict["output_summary"]["final_tokens"] == 4  # "one two nine ten"
+
+def test_pipeline_engine_with_initial_previous_compression(no_op_engine_config: EngineConfig):
+    initial_text = "Initial compressed text by a previous process."
+    initial_trace = CompressionTrace(engine_name="initial_compressor", strategy_params={}, input_summary={}, output_summary={})
+    initial_cm = CompressedMemory(text=initial_text, engine_id="initial", trace=initial_trace)
+
+    pipeline_config = PipelineConfig(engines=[no_op_engine_config]) # Simple pipeline with one NoOp
+    engine = PipelineEngine(config_or_engines=pipeline_config)
+
+    # This text is the "new" text the pipeline is asked to compress, but it should use initial_cm.text for the first engine
+    new_text_for_pipeline = "This is new text, but pipeline should use previous_compression_result's text."
+    budget = len(initial_text) + 10 # Ensure NoOp doesn't truncate initial_text
+
+    result = engine.compress(new_text_for_pipeline, budget, previous_compression_result=initial_cm)
+
+    assert isinstance(result, CompressedMemory)
+    # The NoOp engine will receive initial_cm.text. Since budget is ample, it won't change it.
+    assert result.text == initial_text
+    assert result.engine_id == PipelineEngine.id
+
+    assert isinstance(result.trace, CompressionTrace)
+    assert result.trace.engine_name == PipelineEngine.id
+    # The pipeline's input_summary should reflect the new_text_for_pipeline, not initial_cm's length
+    assert result.trace.input_summary == {"original_length": len(new_text_for_pipeline)}
+    # The pipeline's output_summary should reflect the final text length
+    assert result.trace.output_summary == {"compressed_length": len(initial_text)}
+    assert len(result.trace.steps) == 1
+
+    # The sub-trace for NoOpEngine
+    noop_sub_trace = result.trace.steps[0]
+    assert noop_sub_trace["engine_name"] == NoCompressionEngine.id
+    # Input to NoOpEngine was initial_text
+    assert noop_sub_trace["input_summary"]["input_length"] == len(initial_text)
+    assert noop_sub_trace["output_summary"]["output_length"] == len(initial_text)
+
+def test_pipeline_engine_passes_previous_result_between_engines():
+    # Create mock engines that record the previous_compression_result they received
+    class RecorderEngine(BaseCompressionEngine):
+        id = "recorder"
+        def __init__(self, name="default", **kwargs):
+            super().__init__(**kwargs)
+            self.received_previous_cm = None
+            self.name = name # To distinguish instances
+
+        def compress(self, text: str, budget: int, previous_compression_result: Optional[CompressedMemory] = None, **kwargs) -> CompressedMemory:
+            self.received_previous_cm = previous_compression_result
+            # Return a new CM, possibly modifying text or just passing it along
+            new_text = f"{self.name}_processed_{text}"
+            trace = CompressionTrace(engine_name=self.id, strategy_params={"budget":budget}, input_summary={"original_length":len(text)}, output_summary={"compressed_length":len(new_text)})
+            return CompressedMemory(text=new_text, engine_id=self.id, engine_config=self.config, trace=trace, metadata={"processed_by": self.name})
+
+    engine1 = RecorderEngine(name="eng1")
+    engine2 = RecorderEngine(name="eng2")
+
+    pipeline = PipelineEngine(config_or_engines=[engine1, engine2])
+
+    original_text = "start"
+    budget = 100
+
+    # Test 1: No initial previous_compression_result
+    final_result = pipeline.compress(original_text, budget)
+
+    assert engine1.received_previous_cm is None, "Engine 1 should not have received a previous_compression_result"
+
+    # Engine 2 should have received the CompressedMemory object from Engine 1
+    assert engine2.received_previous_cm is not None
+    assert isinstance(engine2.received_previous_cm, CompressedMemory)
+    assert engine2.received_previous_cm.text == "eng1_processed_start" # Output of engine1
+    assert engine2.received_previous_cm.engine_id == "recorder" # engine1.id
+    assert engine2.received_previous_cm.metadata == {"processed_by": "eng1"}
+
+    assert final_result.text == "eng2_processed_eng1_processed_start"
+
+    # Test 2: With an initial previous_compression_result
+    initial_cm_text = "initial_cm_content"
+    initial_cm = CompressedMemory(text=initial_cm_text, engine_id="initial", trace=CompressionTrace(engine_name="initial", strategy_params={}, input_summary={}, output_summary={}))
+
+    # Reset received_previous_cm for engine instances if they are stateful (they are here)
+    engine1.received_previous_cm = None
+    engine2.received_previous_cm = None
+
+    final_result_with_initial = pipeline.compress("new_text_ignored_for_first_step", budget, previous_compression_result=initial_cm)
+
+    # Engine 1 should receive the initial_cm
+    assert engine1.received_previous_cm is not None
+    assert engine1.received_previous_cm.text == initial_cm_text
+    assert engine1.received_previous_cm.engine_id == "initial"
+
+    # Engine 2 should receive the result from Engine 1 (which processed initial_cm_text)
+    assert engine2.received_previous_cm is not None
+    assert engine2.received_previous_cm.text == f"eng1_processed_{initial_cm_text}"
+    assert engine2.received_previous_cm.engine_id == "recorder"
+    assert engine2.received_previous_cm.metadata == {"processed_by": "eng1"}
+
+    assert final_result_with_initial.text == f"eng2_processed_eng1_processed_{initial_cm_text}"

--- a/tests/test_base_engine.py
+++ b/tests/test_base_engine.py
@@ -2,10 +2,180 @@ from pathlib import Path
 import pytest # For tmp_path fixture if not already using it
 from unittest import mock
 
-from compact_memory.engines import BaseCompressionEngine, load_engine
+from compact_memory.engines import (
+    BaseCompressionEngine,
+    CompressedMemory,
+    CompressionTrace,
+    FirstLastEngine,
+    NoCompressionEngine,
+    load_engine,
+)
 from compact_memory.utils import calculate_sha256
 # Assuming patch_embedding_model from conftest.py sets up a mock embedding function
 # that BaseCompressionEngine will use, providing deterministic embeddings.
+
+# --- Tests for BaseCompressionEngine.compress ---
+
+def test_base_engine_compress_output():
+    engine_config = {"test_param": "test_value"}
+    engine = BaseCompressionEngine(config=engine_config)
+    text = "This is a longer test text for compression."
+    budget = 20
+
+    # Test with previous_compression_result = None
+    result_none = engine.compress(text, budget, previous_compression_result=None)
+
+    assert isinstance(result_none, CompressedMemory)
+    assert result_none.text == text[:budget] # Base engine truncates
+    assert result_none.engine_id == BaseCompressionEngine.id
+    assert result_none.engine_config == engine_config
+    assert isinstance(result_none.trace, CompressionTrace)
+    assert result_none.trace.engine_name == "base_truncate" # Base engine specific trace name
+    assert result_none.trace.strategy_params == {"budget": budget}
+    assert result_none.trace.input_summary == {"original_length": len(text)}
+    assert result_none.trace.output_summary == {"compressed_length": len(text[:budget])}
+
+    # Test with a dummy previous_compression_result
+    dummy_previous_text = "previous compressed text"
+    dummy_previous_trace = CompressionTrace(engine_name="prev_eng", strategy_params={}, input_summary={}, output_summary={})
+    previous_result = CompressedMemory(
+        text=dummy_previous_text,
+        engine_id="prev_eng",
+        engine_config={"prev_config": "val"},
+        trace=dummy_previous_trace
+    )
+    result_with_prev = engine.compress(text, budget, previous_compression_result=previous_result)
+
+    assert isinstance(result_with_prev, CompressedMemory)
+    assert result_with_prev.text == text[:budget] # Base engine ignores previous_compression_result for its logic
+    assert result_with_prev.engine_id == BaseCompressionEngine.id
+    assert result_with_prev.engine_config == engine_config
+    assert isinstance(result_with_prev.trace, CompressionTrace)
+    assert result_with_prev.trace.engine_name == "base_truncate"
+
+
+# --- Tests for NoCompressionEngine.compress ---
+
+def test_no_compression_engine_compress_output():
+    engine_config = {"custom_cfg": "val"}
+    engine = NoCompressionEngine(config=engine_config)
+    text = "This is a test text."
+    budget_full = 100 # Budget larger than text
+    budget_truncate = 10 # Budget smaller than text
+
+    # Test with budget larger than text (no truncation)
+    result_full = engine.compress(text, budget_full)
+    assert isinstance(result_full, CompressedMemory)
+    assert result_full.text == text
+    assert result_full.engine_id == NoCompressionEngine.id
+    assert result_full.engine_config == engine_config # Includes chunker_id by default
+    assert isinstance(result_full.trace, CompressionTrace)
+    assert result_full.trace.engine_name == NoCompressionEngine.id
+    assert result_full.trace.strategy_params == {"llm_token_budget": budget_full} # Specific to this engine's trace
+    assert result_full.trace.input_summary == {"input_length": len(text)}
+    assert result_full.trace.output_summary == {"output_length": len(text)}
+
+    # Test with budget smaller than text (truncation)
+    result_truncate = engine.compress(text, budget_truncate)
+    assert isinstance(result_truncate, CompressedMemory)
+    # NoCompressionEngine uses token_utils.truncate_text, which might not be exact char count
+    # For simplicity, we check length is less than original, assuming truncation happened.
+    # A more precise test would mock tokenizer or use known token counts.
+    assert len(result_truncate.text) <= len(text)
+    if budget_truncate > 0 : # if budget is 0, text can be empty
+      assert len(result_truncate.text) > 0 # Should not be empty if budget > 0 and text is not empty
+    assert result_truncate.engine_id == NoCompressionEngine.id
+    assert isinstance(result_truncate.trace, CompressionTrace)
+    assert result_truncate.trace.engine_name == NoCompressionEngine.id
+    assert result_truncate.trace.strategy_params == {"llm_token_budget": budget_truncate}
+
+    # Test with previous_compression_result
+    dummy_previous = CompressedMemory(text="prev", trace=CompressionTrace(engine_name="dummy", strategy_params={}, input_summary={}, output_summary={}))
+    result_with_prev = engine.compress(text, budget_full, previous_compression_result=dummy_previous)
+    assert isinstance(result_with_prev, CompressedMemory)
+    assert result_with_prev.text == text # Logic should not be affected by previous_compression_result
+
+
+# --- Tests for FirstLastEngine.compress ---
+# Note: FirstLastEngine uses tiktoken by default if available.
+# For robust testing without tiktoken dependency, mock tokenizer or pass a simple one.
+
+def mock_tokenizer(text_input):
+    """A simple mock tokenizer that splits by space and optionally decodes."""
+    class MockTokenized:
+        def __init__(self, tokens):
+            self.tokens = tokens
+        def __len__(self):
+            return len(self.tokens)
+
+    tokens = text_input.split()
+    # Simulate tiktoken's behavior for decode if needed by tests
+    # For FirstLastEngine, it needs a list of tokens from tokenize_text
+    # and then tokenizer.decode(tokens)
+    return tokens
+
+def mock_decode(tokens_list):
+    return " ".join(tokens_list)
+
+@mock.patch("compact_memory.engines.first_last_engine._DEFAULT_TOKENIZER", None) # Ensure tiktoken is not picked up if present
+def test_first_last_engine_compress_output():
+    engine_config = {"test_cfg": "fle_value"}
+    engine = FirstLastEngine(config=engine_config)
+    text = "one two three four five six seven eight nine ten" # 10 words
+
+    # Mock the tokenizer used by FirstLastEngine for deterministic behavior
+    # The engine uses compact_memory.token_utils.tokenize_text, which takes the tokenizer
+    # and the text. Then it uses tokenizer.decode().
+
+    with mock.patch("compact_memory.token_utils.tokenize_text", side_effect=lambda tok, txt: txt.split()) as mock_tokenize_text, \
+         mock.patch.object(engine._chunker, "tokenizer", create=True) as mock_engine_tokenizer: # if engine has own tokenizer for some reason
+        # This part is tricky as FirstLastEngine gets tokenizer from _DEFAULT_TOKENIZER or kwarg
+        # Let's assume we pass it directly or it falls back to split() if _DEFAULT_TOKENIZER is None (mocked above)
+
+        # Test case 1: budget allows all tokens
+        budget_all = 10
+        result_all = engine.compress(text, budget_all, tokenizer=mock_decode) # Pass mock_decode as tokenizer, it will be used for decode
+                                                                            # tokenize_text will use its default split due to _DEFAULT_TOKENIZER mock
+
+        assert isinstance(result_all, CompressedMemory)
+        assert result_all.text == text # Should keep all
+        assert result_all.engine_id == FirstLastEngine.id
+        assert result_all.engine_config == engine_config
+        assert isinstance(result_all.trace, CompressionTrace)
+        assert result_all.trace.engine_name == FirstLastEngine.id
+        assert result_all.trace.strategy_params == {"llm_token_budget": budget_all}
+        assert len(result_all.trace.steps) > 0
+
+        # Test case 2: budget allows first 2 and last 2 (total 4)
+        budget_partial = 4 # half = 2
+        # For "one two three four five six seven eight nine ten"
+        # first 2: "one two"
+        # last 2: "nine ten"
+        # expected: "one two nine ten"
+        expected_partial_text = "one two nine ten"
+        result_partial = engine.compress(text, budget_partial, tokenizer=mock_decode)
+
+        assert isinstance(result_partial, CompressedMemory)
+        assert result_partial.text == expected_partial_text
+        assert result_partial.engine_id == FirstLastEngine.id
+        assert isinstance(result_partial.trace, CompressionTrace)
+        assert result_partial.trace.strategy_params == {"llm_token_budget": budget_partial}
+        assert result_partial.trace.output_summary["final_tokens"] == 4
+
+
+        # Test case 3: budget is 0 or None (should keep all if None, or specific behavior for 0)
+        # Base engine logic for llm_token_budget=None is to keep all.
+        result_none_budget = engine.compress(text, None, tokenizer=mock_decode)
+        assert result_none_budget.text == text
+
+        result_zero_budget = engine.compress(text, 0, tokenizer=mock_decode) # half = 0
+        assert result_zero_budget.text == "" # Keeps tokens[:0] + tokens[-0:] which is empty
+
+        # Test with previous_compression_result
+        dummy_previous = CompressedMemory(text="prev", trace=CompressionTrace(engine_name="dummy", strategy_params={}, input_summary={}, output_summary={}))
+        result_with_prev = engine.compress(text, budget_all, previous_compression_result=dummy_previous, tokenizer=mock_decode)
+        assert isinstance(result_with_prev, CompressedMemory)
+        assert result_with_prev.text == text # Logic should not be affected by previous_compression_result
 
 def test_engine_ingest_and_recall(patch_embedding_model):
     engine = BaseCompressionEngine()
@@ -51,14 +221,14 @@ def test_engine_save_load(tmp_path: Path, patch_embedding_model):
     loaded = load_engine(tmp_path)
     res2 = loaded.recall("world")
     assert res2
-    assert res2[0]['text'] == text_to_ingest
+    assert res2[0]['text'] == text_to_ingest # This part of the test remains valid
 
-    assert loaded.config is not None
-    assert loaded.config.get('my_custom_param') == 'custom_value'
-    assert loaded.config.get('chunker_id') == 'SpecificTestChunker'
+    assert loaded.config is not None # This part of the test remains valid
+    assert loaded.config.get('my_custom_param') == 'custom_value' # This part of the test remains valid
+    assert loaded.config.get('chunker_id') == 'SpecificTestChunker' # This part of the test remains valid
 
 
-# --- Tests for SHA256 Duplicate Detection ---
+# --- Tests for SHA256 Duplicate Detection (These tests are for ingest, not compress, so should be fine) ---
 
 def test_sha256_basic_duplicate_ingestion(patch_embedding_model):
     engine = BaseCompressionEngine()

--- a/tests/test_cli_compress_integration.py
+++ b/tests/test_cli_compress_integration.py
@@ -196,39 +196,13 @@ def test_compress_directory_input_to_output_dir(tmp_path):
     # # Check for "Saved compressed output to..." messages for each file
     # assert f"Saved compressed output to {compressed_a}" in stdout # These messages change with new logic
     # assert f"Saved compressed output to {compressed_b}" in stdout
-    pass # Test is superseded by new directory compression logic
+    # This test is superseded by the new directory compression logic which creates a single combined file.
+    # The new tests are test_compress_directory_default_output_new and test_compress_directory_with_output_dir_new.
+    pass
 
 
-def test_compress_directory_input_default_output(tmp_path):
-    # dir_path = tmp_path / "data_default"
-    # dir_path.mkdir()
-    # file_a = dir_path / "file_one.txt"
-    # file_b = dir_path / "file_two.txt"
-    # file_a.write_text("Default output for file one.")
-    # file_b.write_text("Default output for file two.")
-
-    # result = runner.invoke(
-    #     app, ["compress", "--dir", str(dir_path), "--engine", "none", "--budget", "150"]
-    # )
-    # assert result.exit_code == 0, f"CLI call failed: {result.stderr}\n{result.stdout}"
-
-    # # Verify that _compressed.txt files are created alongside originals
-    # compressed_a_expected = dir_path / "file_one_compressed.txt"
-    # compressed_b_expected = dir_path / "file_two_compressed.txt"
-
-    # assert compressed_a_expected.exists(), "file_one_compressed.txt not found."
-    # assert compressed_b_expected.exists(), "file_two_compressed.txt not found."
-
-    # assert compressed_a_expected.read_text() == "Default output for file one."
-    # assert compressed_b_expected.read_text() == "Default output for file two."
-
-    # # Stdout should show processing messages and save confirmations
-    # stdout = result.stdout
-    # assert f"Processing {file_a}" in stdout
-    # assert f"Processing {file_b}" in stdout
-    # assert f"Saved compressed output to {compressed_a_expected}" in stdout
-    # assert f"Saved compressed output to {compressed_b_expected}" in stdout
-    pass # Test is superseded by new directory compression logic
+# def test_compress_directory_input_default_output(tmp_path): # Superseded
+#     pass
 
 
 def test_compress_empty_directory(tmp_path):
@@ -529,11 +503,10 @@ def test_compress_directory_recursive_pattern_new(tmp_path):
 
 # It's important to comment out or remove the old tests for directory compression
 # as they test a different behavior (per-file output).
-
-# def test_compress_directory_input_to_output_dir(tmp_path):
-# ... (old test) ...
-# def test_compress_directory_input_default_output(tmp_path):
-# ... (old test) ...
+# The tests `test_compress_directory_input_to_output_dir` and
+# `test_compress_directory_input_default_output` are effectively replaced by
+# `test_compress_directory_default_output_new` and
+# `test_compress_directory_with_output_dir_new`.
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This commit introduces a standardized output format for all compression engines and enables engine chaining.

Key changes:
- The `compress` method of all engines now returns a single `CompressedMemory` object.
- The `CompressedMemory` dataclass now includes top-level fields for `engine_id`, `engine_config`, and `trace` (which embeds the `CompressionTrace` object).
- The `compress` method now accepts an optional `previous_compression_result: CompressedMemory` parameter, allowing engines to access the output of a preceding engine in a pipeline.
- Core engines (`BaseCompressionEngine`, `NeocortexTransfer`, `FirstLastEngine`, `NoCompressionEngine`, `StopwordPrunerEngine`) have been updated to this new standard.
- `PipelineEngine` has been updated to manage the flow of `CompressedMemory` objects between sub-engines and to aggregate trace information.
- The CLI's compress command has been updated to handle the new standardized output.
- Unit tests have been added and updated to verify the new return types, data structures, and chaining functionality.
- Documentation for engine developers has been updated to reflect the new API contract.

This standardization simplifies the framework by providing a consistent interface for engine results, making it easier to consume and evaluate them. The chaining capability allows for more flexible and powerful compression strategies by combining multiple engines sequentially.