### PR TITLE
Refactor: Use --dir for Drive folder processing in Colab example

### DIFF
--- a/examples/compact_memory_user_guide.ipynb
+++ b/examples/compact_memory_user_guide.ipynb
@@ -256,6 +256,132 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "### 2.3 Processing a Google Drive Folder\n",
+    "\n",
+    "This section demonstrates how to mount your Google Drive in Colab, select a folder, and then recursively process all text files within that folder using `compact-memory`."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "First, we need to mount your Google Drive to make its files accessible to this Colab environment. When you run the cell below, you'll be prompted to authorize Colab to access your Google Drive."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "After successfully mounting your Drive, you need to specify the path to the folder you want to process. \n",
+    "You can find this path by navigating to your Google Drive in the file explorer panel on the left (usually under '/content/drive/MyDrive/...'). \n",
+    "Copy the full path to your target folder and paste it into the `folder_path` variable in the cell below."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#@title Specify Google Drive Folder Path \n",
+    "folder_path = '' #@param {type:\"string\"}\n",
+    "\n",
+    "if not folder_path: \n",
+    "  print(\"Please enter the path to your Google Drive folder in the 'folder_path' variable.\") \n",
+    "elif not folder_path.startswith('/content/drive'): \n",
+    "  print(f\"The path '{folder_path}' does not look like a valid Google Drive path. It should start with '/content/drive'.\")\n",
+    "else:\n",
+    "  print(f\"Target folder path set to: {folder_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "# Ensure folder_path is defined (it should be from a previous cell where the user inputs it)\n",
+    "if 'folder_path' not in globals() or not folder_path:\n",
+    "    print(\"Error: 'folder_path' is not set. Please run the cell above to set the target folder path.\")\n",
+    "elif not os.path.isdir(folder_path):\n",
+    "    print(f\"Error: The path '{folder_path}' is not a valid directory or does not exist.\")\n",
+    "else:\n",
+    "    print(f\"Attempting to compress all supported files in directory: {folder_path}\")\n",
+    "    \n",
+    "    # Construct the compact-memory command to process the entire directory\n",
+    "    command = [\n",
+    "        \"compact-memory\", \"compress\",\n",
+    "        \"--engine\", \"first_last\",\n",
+    "        \"--dir\", folder_path,\n",
+    "        \"--budget\", \"200\"\n",
+    "        # If you want to save the output to a single JSON file (or other structured format):\n",
+    "        # \"--output\", \"/content/drive/MyDrive/compressed_directory_output.json\" \n",
+    "        # Note: Behavior of --output with --dir might depend on the tool's implementation \n",
+    "        # (e.g., single file with all results, or one file per input file in a new directory).\n",
+    "        # Refer to `compact-memory compress --help` for specifics if needed.\n",
+    "    ]\n",
+    "    \n",
+    "    try:\n",
+    "        result = subprocess.run(command, capture_output=True, text=True, check=False)\n",
+    "        print(\"--- Command Output ---\")\n",
+    "        if result.stdout:\n",
+    "            print(\"Stdout:\")\n",
+    "            print(result.stdout)\n",
+    "        if result.stderr:\n",
+    "            # Always print stderr, as it might contain warnings or progress info even on success\n",
+    "            print(\"Stderr:\")\n",
+    "            print(result.stderr)\n",
+    "        result.check_returncode() # Raise an exception for non-zero exit codes\n",
+    "        print(\"--- Processing Complete ---\")\n",
+    "    except subprocess.CalledProcessError as e:\n",
+    "        print(f\"Error: Command failed with exit code {e.returncode}.\")\n",
+    "        # stdout and stderr were already printed or available in e.stdout, e.stderr if needed again\n",
+    "    except FileNotFoundError:\n",
+    "        print(\"Error: `compact-memory` command not found. Make sure it's installed and in your PATH.\")\n",
+    "        print(\"This can happen if you haven't run the initial setup cells in this notebook (e.g., 'pip install .').\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"An unexpected error occurred: {e}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Understanding the Script and Customization\n",
+    "\n",
+    "The script above performs the following actions:\n",
+    "- It takes the `folder_path` you specified in the preceding cell.\n",
+    "- It constructs and executes a single `compact-memory compress` command using the `--dir` option. This tells `compact-memory` to find and process all supported files (typically text-based files like `.txt`, `.md`, etc.) within the given directory and its subdirectories.\n",
+    "- The `first_last` engine is used with a budget of `200` tokens for the content from the directory.\n",
+    "- The output from the command (compressed text, summaries, or errors) is printed below the cell.\n",
+    "\n",
+    "**Customization Options:**\n",
+    "- **Engine**: Change `--engine first_last` to another engine like `--engine none` or `--engine stopword_pruner` based on your needs.\n",
+    "- **Budget**: Adjust `--budget 200` to a different token limit for the combined content or per-file basis if the engine/CLI supports it with `--dir`.\n",
+    "- **Output**: To save the compressed output, you can add the `--output` flag to the `command` list in the script (e.g., `\"--output\", \"/content/drive/MyDrive/compressed_output.json\"`). The exact format and structure of the output when using `--dir` (e.g., a single file containing all results, or multiple files) depends on the `compact-memory` tool's implementation. You may need to consult `compact-memory compress --help` or experiment to see how output is structured for directory compression.\n",
+    "- **File Selection**: The `--dir` option typically processes files `compact-memory` recognizes. If you need finer control over which files are included or excluded (e.g., specific glob patterns), you would need to check if the `compact-memory` CLI supports additional flags for this with `--dir` (e.g., `--glob \"*.txt\"` or `--exclude \"*.log\"`). If not, and you need very specific filtering, you might revert to a script that iterates files manually (like the previous version of this example) and calls `compact-memory compress --file` for each desired file.\n",
+    "\n",
+    "**Expected Output:**\n",
+    "The script will print a message indicating it's attempting to process the directory. This will be followed by the standard output and standard error from the `compact-memory` command. This output might include a summary of processed files, the compressed content (or a path to it if saved to a file), and any errors or warnings encountered during processing. At the end, a message \"--- Processing Complete ---\" or an error summary will be shown by the Python script."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Choosing a Engine with `--engine`\n",
@@ -298,7 +424,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### 2.4 Other Useful CLI Commands\n",
+    "### 2.5 Other Useful CLI Commands\n",
     "\n",
     "The `compact-memory` CLI offers other utilities. Here are a few, with examples of how to get their help messages:\n",
     "\n",
@@ -323,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Conclusion and Next Steps\n",
+    "## 4. Conclusion and Next Steps\n",
     "\n",
     "This notebook has provided a user-focused introduction to the `compact-memory` library, specifically covering:\n",
     "-   **Installation and Setup**: How to get the library ready for use.\n",


### PR DESCRIPTION
This commit revises the Google Drive folder processing example in the `compact_memory_user_guide.ipynb` Colab notebook.

Responding to your feedback, the Python script now utilizes the `compact-memory compress --dir` command. This approach directly leverages the CLI's built-in capability to recursively process all supported text files within a specified directory using a single command, rather than iterating through files individually in Python.

Changes include:
- The Python script in section "2.3 Processing a Google Drive Folder" has been updated to construct and execute `compact-memory compress --engine first_last --dir <folder_path> --budget 200`.
- The accompanying markdown cell explaining the script's functionality, customization options (including notes on file selection and output handling with `--dir`), and expected output has been updated to accurately reflect the new `--dir` based approach.

This change simplifies the example script and better demonstrates the intended usage of `compact-memory` for directory-level operations.