### PR TITLE
Fix: Ensure consistent file order in directory compression

### DIFF
--- a/src/compact_memory/cli/compress_commands.py
+++ b/src/compact_memory/cli/compress_commands.py
@@ -592,9 +592,9 @@ def _compress_directory_to_files(
     tokenizer: Any,
     ctx: typer.Context,  # Added context
 ) -> None:
-    files_to_process = list(
+    files_to_process = sorted(list(
         dir_path_obj.rglob(pattern) if recursive else dir_path_obj.glob(pattern)
-    )
+    ))
     if not files_to_process:
         typer.echo(f"No files matching pattern '{pattern}' found in '{dir_path_obj}'.")
         return


### PR DESCRIPTION
The 'test_compress_directory_with_output_dir_new' integration test was failing due to non-deterministic order of files when compressing a directory. The 'glob' function doesn't guarantee a sorted list.

This commit fixes the issue by explicitly sorting the file paths obtained from 'glob' (and 'rglob') in the '_compress_directory_to_files' function within 'src/compact_memory/cli/compress_commands.py'. This ensures that the combined content for compression is always created in a predictable order, making the tests reliable and the CLI behavior consistent.

With this change, all tests in 'tests/test_cli_compress_integration.py' now pass.