### PR TITLE
feat: Implement multi-encoder embedding similarity evaluation

### DIFF
--- a/src/compact_memory/cli/dev_commands.py
+++ b/src/compact_memory/cli/dev_commands.py
@@ -154,7 +154,7 @@ def inspect_engine_command(
 
 @dev_app.command(
     "evaluate-compression",
-    help='Evaluates compressed text against original text using a specified metric.\n\nUsage Examples:\n  compact-memory dev evaluate-compression original.txt summary.txt --metric compression_ratio\n  echo "original text" | compact-memory dev evaluate-compression - summary.txt --metric some_other_metric --metric-params \'{"param": "value"}\'',
+    help='Evaluates compressed text against original text using a specified metric.\n\nUsage Examples:\n  compact-memory dev evaluate-compression original.txt summary.txt --metric compression_ratio\n  echo "original text" | compact-memory dev evaluate-compression - summary.txt --metric some_other_metric --metric-params \'{"param": "value"}\'\n  compact-memory dev evaluate-compression original.txt summary.txt --metric multi_model_embedding_similarity --embedding-model "model1" --embedding-model "model2"\n\nNote: When using \'multi_model_embedding_similarity\', the output will show per-model similarity scores and token counts. If --json is used, the \'embedding_similarity\' key will contain a nested dictionary of these scores. Using multiple embedding models can increase evaluation time.',
 )
 def evaluate_compression_command(  # Renamed
     original_input: str = typer.Argument(
@@ -865,7 +865,7 @@ def inspect_trace_command(  # Renamed
 
 @dev_app.command(
     "evaluate-engines",
-    help="Compress text with each specified engine and compute basic metrics.",
+    help="Compresses text with specified engines and evaluates using a predefined set of metrics (compression_ratio and multi_model_embedding_similarity).\n\nThe --embedding-model option configures models for the multi_model_embedding_similarity metric; otherwise, its defaults are used.\nOutput is always JSON, structured as: {engine_id: {\"compression_ratio\": ..., \"embedding_similarity\": {\"model_1\": ..., \"model_2\": ...}}}.\n\nUsage Example:\n  compact-memory dev evaluate-engines --text \"example text to compress\" --engine none --embedding-model \"sentence-transformers/all-MiniLM-L6-v2\"\n\nPerformance Note: Using multiple embedding models via --embedding-model will increase the time taken for each engine's evaluation.",
 )
 def evaluate_engines_command(
     *,

--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -1,9 +1,13 @@
+import json
 from pathlib import Path
 from typer.testing import CliRunner
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from compact_memory.cli import app
+from compact_memory.validation.embedding_metrics import MultiModelEmbeddingSimilarityMetric
+# Import CompressionRatioMetric to mock its evaluate method if needed for evaluate-engines
+from compact_memory.validation.compression_metrics import CompressionRatioMetric # Corrected path
 
-runner = CliRunner(env={"MIX_STDERR": "False"})
+runner = CliRunner(mix_stderr=False)
 
 
 def _env(tmp_path: Path) -> dict[str, str]:
@@ -18,20 +22,16 @@ def test_list_metrics(tmp_path: Path):
     assert result.exit_code == 0
     assert "compression_ratio" in result.stdout
     assert "embedding_similarity_multi" in result.stdout
+    assert "multi_model_embedding_similarity" in result.stdout
 
 
 def test_evaluate_compression_cli(tmp_path: Path, patch_embedding_model):
     result = runner.invoke(
         app,
         [
-            "dev",
-            "evaluate-compression",
-            "hello",
-            "hello",
-            "--metric",
-            "embedding_similarity_multi",
-            "--metric-params",
-            '{"model_names": ["model_a", "model_b"]}',
+            "dev", "evaluate-compression", "hello", "hello",
+            "--metric", "embedding_similarity_multi",
+            "--metric-params", '{"model_names": ["model_a", "model_b"]}',
         ],
         env=_env(tmp_path),
     )
@@ -42,39 +42,30 @@ def test_evaluate_compression_cli(tmp_path: Path, patch_embedding_model):
 
 def test_evaluate_compression_cli_openai_failure(tmp_path: Path, monkeypatch):
     openai_model = "openai/text-embedding-ada-002"
-
     monkeypatch.setattr(
         "compact_memory.validation.embedding_metrics.ep.embed_text",
         lambda *a, **k: [[0.0, 0.0], [0.0, 0.0]],
     )
-    mock_get_tokenizer = MagicMock()
+    mock_get_tokenizer_direct_use = MagicMock()
     monkeypatch.setattr(
         "compact_memory.validation.embedding_metrics.MultiModelEmbeddingSimilarityMetric._get_tokenizer",
-        lambda *a, **k: mock_get_tokenizer(),
+        lambda s, m: mock_get_tokenizer_direct_use(m),
     )
-    tok = MagicMock()
-    tok.model_max_length = 8192
-    mock_get_tokenizer.return_value = tok
+    tok = MagicMock(); tok.model_max_length = 8192
+    mock_get_tokenizer_direct_use.return_value = tok
     monkeypatch.setattr(
         "compact_memory.validation.embedding_metrics.token_utils.token_count",
         lambda *a, **k: 30,
     )
-
     result = runner.invoke(
         app,
         [
-            "dev",
-            "evaluate-compression",
-            "original text",
-            "compressed text",
-            "--metric",
-            "multi_model_embedding_similarity",
-            "--embedding-model",
-            openai_model,
+            "dev", "evaluate-compression", "original text", "compressed text",
+            "--metric", "multi_model_embedding_similarity",
+            "--embedding-model", openai_model,
         ],
         env=_env(tmp_path),
     )
-
     assert result.exit_code == 0
     assert openai_model in result.stdout
     assert "tokens 30" in result.stdout
@@ -84,14 +75,146 @@ def test_evaluate_llm_response_cli(tmp_path: Path):
     result = runner.invoke(
         app,
         [
-            "dev",
-            "evaluate-llm-response",
-            "hello",
-            "hello",
-            "--metric",
-            "exact_match",
+            "dev", "evaluate-llm-response", "hello", "hello",
+            "--metric", "exact_match",
         ],
         env=_env(tmp_path),
     )
     assert result.exit_code == 0
     assert "exact_match" in result.stdout
+
+
+def test_evaluate_compression_multi_model_cli(tmp_path: Path, monkeypatch):
+    original_text = "original sample text"; compressed_text = "compressed sample text"
+    metric_id = "multi_model_embedding_similarity"
+    evaluate_method_path_on_class = "compact_memory.validation.embedding_metrics.MultiModelEmbeddingSimilarityMetric.evaluate"
+
+    # Scenario 1
+    mock_data_scen1 = {"embedding_similarity": {"mock-model-1": {"similarity": 0.8, "token_count": 10}, "mock-model-2": {"similarity": 0.9, "token_count": 20}}}
+    mock_evaluate_scen1 = MagicMock(return_value=mock_data_scen1)
+    monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen1)
+    result_scen1 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id, "--embedding-model", "mock-model-1", "--embedding-model", "mock-model-2"], env=_env(tmp_path))
+    assert result_scen1.exit_code == 0, f"STDOUT: {result_scen1.stdout}\nSTDERR: {result_scen1.stderr}"
+    assert "Scores for metric 'multi_model_embedding_similarity':" in result_scen1.stdout
+    assert "- mock-model-1: similarity 0.8, tokens 10" in result_scen1.stdout
+    assert "- mock-model-2: similarity 0.9, tokens 20" in result_scen1.stdout
+    mock_evaluate_scen1.assert_called_once()
+
+    # Scenario 2
+    mock_data_scen2 = {"embedding_similarity": {"mock-model-3": {"similarity": 0.7, "token_count": 15}, "mock-model-4": {"similarity": 0.85, "token_count": 25}}}
+    mock_evaluate_scen2 = MagicMock(return_value=mock_data_scen2)
+    monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen2)
+    result_scen2 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id, "--embedding-model", '["mock-model-3", "mock-model-4"]'], env=_env(tmp_path))
+    assert result_scen2.exit_code == 0, f"STDOUT: {result_scen2.stdout}\nSTDERR: {result_scen2.stderr}"
+    assert "Scores for metric 'multi_model_embedding_similarity':" in result_scen2.stdout
+    assert "- mock-model-3: similarity 0.7, tokens 15" in result_scen2.stdout
+    assert "- mock-model-4: similarity 0.85, tokens 25" in result_scen2.stdout
+    mock_evaluate_scen2.assert_called_once()
+
+    # Scenario 3
+    default_model_1 = "sentence-transformers/all-MiniLM-L6-v2"; default_model_2 = "sentence-transformers/all-mpnet-base-v2"
+    mock_data_scen3 = {"embedding_similarity": {default_model_1: {"similarity": 0.91, "token_count": 30}, default_model_2: {"similarity": 0.92, "token_count": 35}}}
+    mock_evaluate_scen3 = MagicMock(return_value=mock_data_scen3)
+    monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen3)
+    result_scen3 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id], env=_env(tmp_path))
+    assert result_scen3.exit_code == 0, f"STDOUT: {result_scen3.stdout}\nSTDERR: {result_scen3.stderr}"
+    assert "Scores for metric 'multi_model_embedding_similarity':" in result_scen3.stdout
+    assert f"- {default_model_1}: similarity 0.91, tokens 30" in result_scen3.stdout
+    assert f"- {default_model_2}: similarity 0.92, tokens 35" in result_scen3.stdout
+    mock_evaluate_scen3.assert_called_once()
+
+    # Scenario 4
+    mock_data_scen4 = {"embedding_similarity": {"mock-model-1": {"similarity": 0.8, "token_count": 10}, "mock-model-2": {"similarity": 0.9, "token_count": 20}}}
+    mock_evaluate_scen4 = MagicMock(return_value=mock_data_scen4)
+    monkeypatch.setattr(evaluate_method_path_on_class, mock_evaluate_scen4)
+    result_scen4 = runner.invoke(app, ["dev", "evaluate-compression", original_text, compressed_text, "--metric", metric_id, "--embedding-model", "mock-model-1", "--embedding-model", "mock-model-2", "--json"], env=_env(tmp_path))
+    assert result_scen4.exit_code == 0, f"STDOUT: {result_scen4.stdout}\nSTDERR: {result_scen4.stderr}"
+    parsed_json_output = json.loads(result_scen4.stdout)
+    assert parsed_json_output == mock_data_scen4
+    mock_evaluate_scen4.assert_called_once()
+
+
+def test_evaluate_engines_multi_model_cli(tmp_path: Path, monkeypatch):
+    test_text = "This is example text for engine evaluation."
+    engine_id = "none"
+    # The evaluate-engines command runs a fixed set of metrics, including
+    # MultiModelEmbeddingSimilarityMetric (results under "embedding_similarity" key)
+    # and CompressionRatioMetric (results under "compression_ratio" key).
+
+    # Mock for MultiModelEmbeddingSimilarityMetric.evaluate
+    mms_evaluate_path = "compact_memory.validation.embedding_metrics.MultiModelEmbeddingSimilarityMetric.evaluate"
+    mock_mms_evaluate_method = MagicMock()
+    monkeypatch.setattr(mms_evaluate_path, mock_mms_evaluate_method)
+
+    # Mock for CompressionRatioMetric.evaluate - to prevent it from actually calculating
+    # and to control its output value.
+    cr_evaluate_path = "compact_memory.validation.compression_metrics.CompressionRatioMetric.evaluate" # Corrected path
+    mock_cr_evaluate_method = MagicMock(return_value={"compression_ratio": 0.5})
+    monkeypatch.setattr(cr_evaluate_path, mock_cr_evaluate_method)
+
+    # Scenario 1 (was default run, now explicit): Multiple --embedding-model flags
+    mock_mms_data_scen1 = {
+        "embedding_similarity": { # This is the structure MultiModelEmbeddingSimilarityMetric.evaluate returns
+            "mock-model-1": {"similarity": 0.81, "token_count": 11},
+            "mock-model-2": {"similarity": 0.91, "token_count": 21}
+        }
+    }
+    mock_mms_evaluate_method.return_value = mock_mms_data_scen1
+
+    result_scen1 = runner.invoke(
+        app,
+        [
+            "dev", "evaluate-engines", "--text", test_text,
+            "--engine", engine_id,
+            # No --metrics flag, it runs default metrics including MultiModel...
+            "--embedding-model", "mock-model-1",
+            "--embedding-model", "mock-model-2"
+        ],
+        env=_env(tmp_path)
+    )
+    if result_scen1.exit_code != 0:
+        print(f"Scenario 1 STDOUT: {result_scen1.stdout}")
+        print(f"Scenario 1 STDERR: {result_scen1.stderr}")
+    assert result_scen1.exit_code == 0
+    mock_mms_evaluate_method.assert_called_once()
+    mock_cr_evaluate_method.assert_called_once() # Should also be called
+
+    parsed_output_scen1 = json.loads(result_scen1.stdout)
+    assert engine_id in parsed_output_scen1
+    # The key in results is "embedding_similarity", not "multi_model_embedding_similarity"
+    assert "embedding_similarity" in parsed_output_scen1[engine_id]
+    assert parsed_output_scen1[engine_id]["embedding_similarity"] == mock_mms_data_scen1["embedding_similarity"]
+    assert "compression_ratio" in parsed_output_scen1[engine_id]
+    assert parsed_output_scen1[engine_id]["compression_ratio"] == 0.5
+
+    mock_mms_evaluate_method.reset_mock()
+    mock_cr_evaluate_method.reset_mock()
+
+    # Scenario 2: JSON list for --embedding-model
+    mock_mms_data_scen2 = {"embedding_similarity": {"mock-model-3": {"similarity": 0.71, "token_count": 16}, "mock-model-4": {"similarity": 0.86, "token_count": 26}}}
+    mock_mms_evaluate_method.return_value = mock_mms_data_scen2
+    result_scen2 = runner.invoke(app, ["dev", "evaluate-engines", "--text", test_text, "--engine", engine_id, "--embedding-model", '["mock-model-3", "mock-model-4"]'], env=_env(tmp_path))
+    assert result_scen2.exit_code == 0, f"STDOUT: {result_scen2.stdout}\nSTDERR: {result_scen2.stderr}"
+    mock_mms_evaluate_method.assert_called_once()
+    mock_cr_evaluate_method.assert_called_once()
+    parsed_output_scen2 = json.loads(result_scen2.stdout)
+    assert parsed_output_scen2[engine_id]["embedding_similarity"] == mock_mms_data_scen2["embedding_similarity"]
+    assert parsed_output_scen2[engine_id]["compression_ratio"] == 0.5
+    mock_mms_evaluate_method.reset_mock()
+    mock_cr_evaluate_method.reset_mock()
+
+    # Scenario 3: Default embedding models (no --embedding-model flag)
+    default_model_1 = "sentence-transformers/all-MiniLM-L6-v2"
+    default_model_2 = "sentence-transformers/all-mpnet-base-v2"
+    mock_mms_data_default = {"embedding_similarity": {default_model_1: {"similarity": 0.93, "token_count": 31}, default_model_2: {"similarity": 0.94, "token_count": 36}}}
+    mock_mms_evaluate_method.return_value = mock_mms_data_default
+    result_scen3 = runner.invoke(app, ["dev", "evaluate-engines", "--text", test_text, "--engine", engine_id], env=_env(tmp_path))
+    assert result_scen3.exit_code == 0, f"STDOUT: {result_scen3.stdout}\nSTDERR: {result_scen3.stderr}"
+    mock_mms_evaluate_method.assert_called_once()
+    mock_cr_evaluate_method.assert_called_once()
+    parsed_output_scen3 = json.loads(result_scen3.stdout)
+    assert parsed_output_scen3[engine_id]["embedding_similarity"] == mock_mms_data_default["embedding_similarity"]
+    assert parsed_output_scen3[engine_id]["compression_ratio"] == 0.5
+
+    # This part of the test (checking other metric not called) is not needed anymore
+    # as evaluate-engines does not filter metrics via CLI option. It runs its predefined set.

--- a/tests/test_embedding_similarity_metric.py
+++ b/tests/test_embedding_similarity_metric.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest # Added import
 from compact_memory.validation.embedding_metrics import (
     EmbeddingSimilarityMetric,
     MultiEmbeddingSimilarityMetric,
@@ -27,7 +28,8 @@ def test_multi_similarity_returns_per_model_scores(patch_embedding_model, monkey
         return {"model_a": enc_a, "model_b": enc_b}[name]
 
     monkeypatch.setattr(ep, "_load_model", fake_load)
-    metric = MultiEmbeddingSimilarityMetric(model_names=["model_a", "model_b"])
+    with pytest.warns(DeprecationWarning, match="MultiEmbeddingSimilarityMetric is deprecated"):
+        metric = MultiEmbeddingSimilarityMetric(model_names=["model_a", "model_b"])
     scores = metric.evaluate(original_text="hello", compressed_text="hello")
     assert set(scores) == {
         "semantic_similarity",
@@ -46,7 +48,8 @@ def test_multi_similarity_skips_when_too_long(patch_embedding_model, monkeypatch
         model_max_length = 2
 
     monkeypatch.setattr(ep, "_load_model", lambda *a, **k: SmallEncoder())
-    metric = MultiEmbeddingSimilarityMetric(model_names=["small"], max_tokens=10)
+    with pytest.warns(DeprecationWarning, match="MultiEmbeddingSimilarityMetric is deprecated"):
+        metric = MultiEmbeddingSimilarityMetric(model_names=["small"], max_tokens=10)
     text = "one two three four"
     scores = metric.evaluate(original_text=text, compressed_text=text)
     assert list(scores) == ["token_count"]

--- a/tests/test_multi_model_embedding_similarity_metric.py
+++ b/tests/test_multi_model_embedding_similarity_metric.py
@@ -1,285 +1,310 @@
 import numpy as np
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+import pytest
+import tiktoken
+import transformers
+
 from compact_memory.validation.embedding_metrics import (
     MultiModelEmbeddingSimilarityMetric,
 )
+from compact_memory import embedding_pipeline as ep
 
 
-def test_multi_model_embedding_similarity_basic(patch_embedding_model):
+def test_multi_model_embedding_similarity_basic(monkeypatch):
+    mock_autotokenizer_class = MagicMock(spec=transformers.AutoTokenizer)
+    mock_tokenizer_instance = MagicMock()
+    mock_tokenizer_instance.model_max_length = 128
+    mock_autotokenizer_class.from_pretrained.return_value = mock_tokenizer_instance
+    monkeypatch.setattr(transformers, "AutoTokenizer", mock_autotokenizer_class)
+
+    mock_tu_token_count = MagicMock(side_effect=[1, 1, 1])
+    monkeypatch.setattr('compact_memory.validation.embedding_metrics.token_utils.token_count', mock_tu_token_count)
+
+    fixed_vector = [1.0, 0.0]
+    mock_ep_embed = MagicMock(return_value=[fixed_vector, fixed_vector])
+    monkeypatch.setattr(ep, "embed_text", mock_ep_embed)
+
     metric = MultiModelEmbeddingSimilarityMetric(model_names=["dummy-model"])
     scores = metric.evaluate(original_text="hello", compressed_text="hello")
+
+    assert "dummy-model" in scores["embedding_similarity"]
     data = scores["embedding_similarity"]["dummy-model"]
     assert np.isclose(data["similarity"], 1.0)
     assert data["token_count"] == 1
 
 
-def test_multi_model_embedding_similarity_skip_long(patch_embedding_model):
-    metric = MultiModelEmbeddingSimilarityMetric(model_names=["dummy-model"])
+def test_multi_model_embedding_similarity_skip_long(monkeypatch, caplog):
+    mock_autotokenizer_class = MagicMock(spec=transformers.AutoTokenizer)
+    mock_tokenizer_instance = MagicMock()
+    mock_tokenizer_instance.model_max_length = 128
+    mock_autotokenizer_class.from_pretrained.return_value = mock_tokenizer_instance
+    monkeypatch.setattr(transformers, "AutoTokenizer", mock_autotokenizer_class)
+
+    long_text_token_count_a = 200
+    long_text_token_count_b = 200
+    mock_tu_token_count = MagicMock(side_effect=[long_text_token_count_a, long_text_token_count_b])
+    monkeypatch.setattr('compact_memory.validation.embedding_metrics.token_utils.token_count', mock_tu_token_count)
+
+    mock_ep_embed = MagicMock()
+    monkeypatch.setattr(ep, "embed_text", mock_ep_embed)
+
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=["dummy-model-hf"])
     long_text = " ".join("t" + str(i) for i in range(200))
     scores = metric.evaluate(original_text=long_text, compressed_text=long_text)
+
     assert scores["embedding_similarity"] == {}
+    mock_ep_embed.assert_not_called()
+    assert any(record.levelname == "WARNING" and "Input exceeds model_max_length for dummy-model-hf; skipping" in record.message for record in caplog.records)
 
 
-def test_multi_model_embedding_similarity_multiple_hf_models(monkeypatch):
-    # 1. Patch target functions
-    mock_embed_text = MagicMock()
-    monkeypatch.setattr(
-        "compact_memory.validation.embedding_metrics.ep.embed_text", mock_embed_text
-    )
-    mock_token_count = MagicMock()
-    monkeypatch.setattr(
-        "compact_memory.validation.embedding_metrics.token_utils.token_count",
-        mock_token_count,
-    )
+def test_multi_model_embedding_similarity_multiple_hf_models(monkeypatch, caplog):
+    mock_autotokenizer_class = MagicMock(spec=transformers.AutoTokenizer)
+    mock_hf_tokenizer_instance_1 = MagicMock(); mock_hf_tokenizer_instance_1.model_max_length = 128
+    mock_hf_tokenizer_instance_2 = MagicMock(); mock_hf_tokenizer_instance_2.model_max_length = 128
 
-    # 2. Define mock behaviors
-    def embed_text_side_effect(
-        texts, model_name, encoder_model=None, tokenizer=None, **kwargs
-    ):
-        print(
-            f"embed_text_side_effect: texts='{texts}', model_name='{model_name}', encoder_model is None: {encoder_model is None}, tokenizer is None: {tokenizer is None}"
-        )
+    def from_pretrained_side_effect(model_name_arg, **kwargs):
+        if model_name_arg == "hf_model_1": return mock_hf_tokenizer_instance_1
+        if model_name_arg == "hf_model_2": return mock_hf_tokenizer_instance_2
+        pytest.fail(f"Unexpected model name for AutoTokenizer: {model_name_arg}")
+    mock_autotokenizer_class.from_pretrained.side_effect = from_pretrained_side_effect
+    monkeypatch.setattr(transformers, "AutoTokenizer", mock_autotokenizer_class)
 
-        if (
-            len(texts) == 2
-        ):  # Batch call from the metric directly: ep.embed_text([text_a, text_b], model_name=name)
-            original_text_val = texts[0]
-            compressed_text_val = texts[1]
+    mock_embed_text_hf = MagicMock()
+    monkeypatch.setattr(ep, "embed_text", mock_embed_text_hf)
 
-            embedding_original = [0.0, 0.0]  # Default
-            embedding_compressed = [0.0, 0.0]  # Default
+    mock_token_count = MagicMock(side_effect=[ 10, 10, 10, 20, 20, 20 ])
+    monkeypatch.setattr('compact_memory.validation.embedding_metrics.token_utils.token_count', mock_token_count)
 
-            if model_name == "hf_model_1":
-                if original_text_val == "original text":
-                    embedding_original = [0.1, 0.2]
-                if compressed_text_val == "compressed text":
-                    embedding_compressed = [0.3, 0.4]
-            elif model_name == "hf_model_2":
-                if original_text_val == "original text":
-                    embedding_original = [0.5, 0.6]
-                if compressed_text_val == "compressed text":
-                    embedding_compressed = [0.7, 0.8]
+    def embed_text_side_effect_multi(texts, model_name, **kwargs):
+        if model_name == "hf_model_1": return [[0.1, 0.2], [0.3, 0.4]]
+        if model_name == "hf_model_2": return [[0.5, 0.6], [0.7, 0.8]]
+        pytest.fail(f"Unexpected model name for embed_text: {model_name}")
+    mock_embed_text_hf.side_effect = embed_text_side_effect_multi
 
-            print(
-                f"Batch call for {model_name}: returning {[embedding_original, embedding_compressed]}"
-            )
-            return [embedding_original, embedding_compressed]
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=["hf_model_1", "hf_model_2"])
+    result = metric.evaluate(original_text="original text", compressed_text="compressed text")
 
-        elif len(texts) == 1:  # Individual call (likely from EmbedderPipeline instance)
-            text = texts[0]
-            # These calls might be for text splitting logic or other checks,
-            # not necessarily the ones directly used for the final similarity score.
-            # Provide consistent embeddings.
-            if model_name == "hf_model_1":
-                if text == "original text":
-                    print(
-                        f"Individual call for {model_name}, '{text}': returning [[0.1, 0.2]]"
-                    )
-                    return [[0.1, 0.2]]
-                elif text == "compressed text":
-                    print(
-                        f"Individual call for {model_name}, '{text}': returning [[0.3, 0.4]]"
-                    )
-                    return [[0.3, 0.4]]
-            elif model_name == "hf_model_2":
-                if text == "original text":
-                    print(
-                        f"Individual call for {model_name}, '{text}': returning [[0.5, 0.6]]"
-                    )
-                    return [[0.5, 0.6]]
-                elif text == "compressed text":
-                    print(
-                        f"Individual call for {model_name}, '{text}': returning [[0.7, 0.8]]"
-                    )
-                    return [[0.7, 0.8]]
-
-            print(
-                f"Individual call for {model_name}, '{text}': defaulting to [[0.0, 0.0]]"
-            )
-            return [[0.0, 0.0]]
-
-        # Fallback for unexpected number of texts
-        print(f"Unexpected number of texts ({len(texts)}) for {model_name}: defaulting")
-        return [[0.0, 0.0]] * len(texts) if texts else []
-
-    mock_embed_text.side_effect = embed_text_side_effect
-
-    # State for token_count_side_effect
-    # Maps tokenizer object ID to a pre-assigned model name ("hf_model_1" or "hf_model_2")
-    tokenizer_object_to_model_name_map = {}
-    # Assumes model_names in metric are processed in this order for initial mapping
-    model_names_in_processing_order = ["hf_model_1", "hf_model_2"]
-
-    # The call from source code is token_utils.token_count(tokenizer_object, text_string)
-    # tokenizer_object is a DummyTokenizer instance. Log shows these are different for different models.
-    def token_count_side_effect(tokenizer_dummy_obj, text_content_str, **kwargs):
-
-        obj_id = id(tokenizer_dummy_obj)
-        current_model_name = tokenizer_object_to_model_name_map.get(obj_id)
-
-        if current_model_name is None:  # First time seeing this tokenizer object
-            # Assign it the next available model name based on processing order
-            if len(tokenizer_object_to_model_name_map) < len(
-                model_names_in_processing_order
-            ):
-                current_model_name = model_names_in_processing_order[
-                    len(tokenizer_object_to_model_name_map)
-                ]
-                tokenizer_object_to_model_name_map[obj_id] = current_model_name
-            else:
-                # Should not happen if only 2 models are used and processed once for tokenizers
-                current_model_name = "unknown_model_obj_id_" + str(obj_id)
-
-        print(
-            f"token_count_side_effect: text='{text_content_str}', model='{current_model_name}' (from obj id {obj_id})"
-        )
-
-        count_to_return = 0
-        # We only care about returning specific counts for "compressed text" for the models under test.
-        # Other calls (e.g., for "original text", or from text_is_too_long path if args are swapped) should get a default.
-        if text_content_str == "compressed text":
-            if current_model_name == "hf_model_1":
-                print(f"Returning 10 for {current_model_name} 'compressed text'")
-                count_to_return = 10
-            elif current_model_name == "hf_model_2":
-                print(f"Returning 20 for {current_model_name} 'compressed text'")
-                count_to_return = 20
-            else:
-                print(
-                    f"Unknown model '{current_model_name}' for 'compressed text', returning 0"
-                )
-                count_to_return = 0
-        else:
-            # For "original text", or if text_content_str is actually a tokenizer obj due to swapped args from text_is_too_long
-            print(
-                f"Text ('{text_content_str}') not 'compressed text' for model '{current_model_name}', or args swapped; returning 0"
-            )
-            count_to_return = 0
-
-        return count_to_return
-
-    mock_token_count.side_effect = token_count_side_effect
-
-    # 3. Instantiate MultiModelEmbeddingSimilarityMetric
-    metric = MultiModelEmbeddingSimilarityMetric(
-        model_names=["hf_model_1", "hf_model_2"]
-    )
-
-    # 4. Call evaluate
-    result = metric.evaluate(
-        original_text="original text", compressed_text="compressed text"
-    )
-
-    # 5. Assertions
-    assert "embedding_similarity" in result
-    es_results = result["embedding_similarity"]
-
+    assert "embedding_similarity" in result; es_results = result["embedding_similarity"]
     assert "hf_model_1" in es_results
-    assert np.isclose(
-        es_results["hf_model_1"]["similarity"], np.dot([0.1, 0.2], [0.3, 0.4])
-    )  # 0.03 + 0.08 = 0.11
+    assert np.isclose(es_results["hf_model_1"]["similarity"], np.dot([0.1, 0.2], [0.3, 0.4]))
     assert es_results["hf_model_1"]["token_count"] == 10
-
     assert "hf_model_2" in es_results
-    assert np.isclose(
-        es_results["hf_model_2"]["similarity"], np.dot([0.5, 0.6], [0.7, 0.8])
-    )  # 0.35 + 0.48 = 0.83
+    assert np.isclose(es_results["hf_model_2"]["similarity"], np.dot([0.5, 0.6], [0.7, 0.8]))
     assert es_results["hf_model_2"]["token_count"] == 20
 
 
-def test_multi_model_openai_embedding_failure(monkeypatch):
-    # 1. Patch necessary functions/methods
+def test_multi_model_openai_embedding_failure(monkeypatch, caplog):
     mock_ep_embed_text = MagicMock()
-    monkeypatch.setattr(
-        "compact_memory.validation.embedding_metrics.ep.embed_text",
-        mock_ep_embed_text,
-    )
+    monkeypatch.setattr(ep, "embed_text", mock_ep_embed_text)
     mock_token_utils_token_count = MagicMock()
-    monkeypatch.setattr(
-        "compact_memory.validation.embedding_metrics.token_utils.token_count",
-        mock_token_utils_token_count,
-    )
-    mock_get_tokenizer = MagicMock()
-    monkeypatch.setattr(
-        "compact_memory.validation.embedding_metrics.MultiModelEmbeddingSimilarityMetric._get_tokenizer",
-        mock_get_tokenizer,
-    )
+    monkeypatch.setattr('compact_memory.validation.embedding_metrics.token_utils.token_count', mock_token_utils_token_count)
 
-    # 2. Define mock behaviors
+    mock_actual_get_tokenizer = MagicMock()
+    mock_openai_tokenizer_inst = MagicMock(spec=tiktoken.Encoding)
+    mock_openai_tokenizer_inst.model_max_length = 8192
+    mock_actual_get_tokenizer.return_value = mock_openai_tokenizer_inst
+    monkeypatch.setattr(MultiModelEmbeddingSimilarityMetric, "_get_tokenizer", mock_actual_get_tokenizer)
+
     openai_model_name = "openai/text-embedding-ada-002"
+    mock_ep_embed_text.side_effect = Exception("Simulated embedding error")
+    mock_token_utils_token_count.side_effect = [30,30,30]
 
-    # Mock for _get_tokenizer
-    mock_openai_tokenizer = MagicMock()
-    mock_openai_tokenizer.model_max_length = 8192
-    mock_get_tokenizer.return_value = mock_openai_tokenizer
-
-    # Mock for ep.embed_text (global embedder)
-    def embed_text_side_effect(
-        texts, model_name, encoder_model=None, tokenizer=None, **kwargs
-    ):
-        print(f"ep.embed_text called with: texts='{texts}', model_name='{model_name}'")
-        if model_name == openai_model_name:
-            # Simulate failure for OpenAI model by returning zero embeddings for the batch call
-            print(
-                f"Simulating embedding failure for {openai_model_name}, returning zero embeddings."
-            )
-            # It's a batch call from the metric: expects list of 2 embeddings
-            return [[0.0, 0.0], [0.0, 0.0]]
-        # Fallback for other models/calls if any (not expected in this test)
-        return [[0.0, 0.0]] * len(texts) if texts else []
-
-    mock_ep_embed_text.side_effect = embed_text_side_effect
-
-    # Mock for token_utils.token_count
-    # This mock needs to handle two call signatures due to how it's used in the codebase:
-    # 1. Direct call: token_utils.token_count(tokenizer_object, text_string)
-    # 2. Via Tokenizer.token_count: token_utils.token_count(text_string, hf_dummy_tokenizer, model_name_string)
-    def token_count_side_effect(*args, **kwargs):
-        # Check the type of the first argument to differentiate call patterns
-        arg1 = args[0]
-
-        if isinstance(
-            arg1, str
-        ):  # Call from Tokenizer.token_count(text, hf_dummy, model_name)
-            text_content_str = arg1
-            # arg2 is hf_dummy_tokenizer, arg3 is model_name_str (passed as kwarg or positional)
-            # This path is mainly for text_is_too_long, not for the primary token count assertion.
-            # We can return a default value or make it more specific if needed.
-            print(
-                f"token_utils.token_count (via Tokenizer.token_count): text='{text_content_str}', args='{args}'"
-            )
-            return 0  # Default for this path
-        else:  # Direct call: token_utils.token_count(tokenizer_object, text_string)
-            tokenizer_obj = arg1
-            text_content_str = args[1]
-            print(
-                f"token_utils.token_count (direct): text='{text_content_str}', tokenizer_obj='{tokenizer_obj}'"
-            )
-            if (
-                tokenizer_obj == mock_openai_tokenizer
-                and text_content_str == "compressed text"
-            ):
-                print(f"Returning 30 for OpenAI tokenizer and 'compressed text'")
-                return 30
-            return 0  # Default for other direct calls
-
-    mock_token_utils_token_count.side_effect = token_count_side_effect
-
-    # 3. Instantiate MultiModelEmbeddingSimilarityMetric
     metric = MultiModelEmbeddingSimilarityMetric(model_names=[openai_model_name])
+    result = metric.evaluate(original_text="original text", compressed_text="compressed text")
 
-    # 4. Call evaluate
-    result = metric.evaluate(
-        original_text="original text", compressed_text="compressed text"
-    )
-
-    # 5. Assertions
-    assert "embedding_similarity" in result
-    es_results = result["embedding_similarity"]
-
-    assert openai_model_name in es_results
-    openai_result = es_results[openai_model_name]
-
+    mock_actual_get_tokenizer.assert_called_with(openai_model_name)
+    assert "embedding_similarity" in result; es_results = result["embedding_similarity"]
+    assert openai_model_name in es_results; openai_result = es_results[openai_model_name]
     assert openai_result["token_count"] == 30
-    # If ep.embed_text returned [[0.0,0.0], [0.0,0.0]], then similarity = dot([0,0],[0,0]) = 0.0
     assert np.isclose(openai_result["similarity"], 0.0)
+    assert any(record.levelname == "WARNING" and f"Embedding failed for {openai_model_name}" in record.message for record in caplog.records)
+
+
+@patch('tiktoken.get_encoding', autospec=True)
+@patch('tiktoken.encoding_for_model', autospec=True)
+def test_openai_tokenizer_max_length_determination(mock_encoding_for_model, mock_get_encoding):
+    metric = MultiModelEmbeddingSimilarityMetric()
+    model_name_ada = "openai/text-embedding-ada-002"; expected_max_len_ada = 8191
+    mock_tok_ada = MagicMock(spec=tiktoken.Encoding); mock_encoding_for_model.return_value = mock_tok_ada
+    tokenizer_ada = metric._get_tokenizer(model_name_ada)
+    assert tokenizer_ada.model_max_length == expected_max_len_ada; mock_encoding_for_model.assert_called_with(model_name_ada.split("/", 1)[1])
+    mock_encoding_for_model.reset_mock(); mock_get_encoding.reset_mock()
+    model_name_custom_mml = "openai/custom-mml-model"; expected_max_len_custom_mml = 4000
+    mock_tok_custom_mml = MagicMock(spec=tiktoken.Encoding); mock_tok_custom_mml.model_max_length = expected_max_len_custom_mml; mock_tok_custom_mml.n_ctx = None
+    mock_encoding_for_model.return_value = mock_tok_custom_mml
+    tokenizer_custom_mml = metric._get_tokenizer(model_name_custom_mml)
+    assert tokenizer_custom_mml.model_max_length == expected_max_len_custom_mml
+    mock_encoding_for_model.reset_mock(); mock_get_encoding.reset_mock()
+    model_name_nctx = "openai/custom-nctx-model"; expected_max_len_nctx = 2048
+    mock_tok_nctx = MagicMock(spec=tiktoken.Encoding); mock_tok_nctx.model_max_length = None; mock_tok_nctx.n_ctx = expected_max_len_nctx
+    mock_encoding_for_model.return_value = mock_tok_nctx
+    tokenizer_nctx = metric._get_tokenizer(model_name_nctx)
+    assert tokenizer_nctx.model_max_length == expected_max_len_nctx
+    mock_encoding_for_model.reset_mock(); mock_get_encoding.reset_mock()
+    model_name_unknown = "openai/unknown-model"; expected_max_len_default = 8191
+    mock_tok_unknown = MagicMock(spec=tiktoken.Encoding); mock_tok_unknown.model_max_length = None; mock_tok_unknown.n_ctx = None
+    mock_encoding_for_model.return_value = mock_tok_unknown
+    tokenizer_unknown = metric._get_tokenizer(model_name_unknown)
+    assert tokenizer_unknown.model_max_length == expected_max_len_default
+    mock_encoding_for_model.reset_mock(); mock_get_encoding.reset_mock()
+    model_name_unavailable = "openai/unavailable-model"; expected_max_len_gpt2_fallback = 1024
+    mock_encoding_for_model.side_effect = Exception("Test encoding failure")
+    mock_gpt2_tokenizer = MagicMock(spec=tiktoken.Encoding); mock_gpt2_tokenizer.model_max_length = None; mock_gpt2_tokenizer.n_ctx = expected_max_len_gpt2_fallback
+    mock_get_encoding.return_value = mock_gpt2_tokenizer
+    tokenizer_fallback = metric._get_tokenizer(model_name_unavailable)
+    assert tokenizer_fallback.model_max_length == expected_max_len_gpt2_fallback; mock_get_encoding.assert_called_once_with("gpt2")
+
+
+def test_openai_token_counting_and_skipping(monkeypatch, caplog):
+    openai_model_name = "openai/text-embedding-ada-002"; ada_base_model_name = "text-embedding-ada-002"
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=[openai_model_name])
+    original_text = "This is a short original text."; compressed_text = "This is a short compressed text."
+    mock_embed_text_oai = MagicMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
+    monkeypatch.setattr(ep, "embed_text", mock_embed_text_oai)
+    results = metric.evaluate(original_text=original_text, compressed_text=compressed_text)
+    try: enc = tiktoken.encoding_for_model(ada_base_model_name); expected_token_count = len(enc.encode(compressed_text))
+    except Exception as e: pytest.fail(f"Failed to get tiktoken encoding for {ada_base_model_name}: {e}")
+    assert openai_model_name in results["embedding_similarity"]
+    model_results = results["embedding_similarity"][openai_model_name]
+    assert model_results["token_count"] == expected_token_count
+    assert np.isclose(model_results["similarity"], np.dot([0.1, 0.2], [0.3, 0.4]))
+    mock_embed_text_oai.assert_called_once()
+
+    mock_embed_text_oai.reset_mock(); caplog.clear()
+    long_original_text = " a" * 8200; short_compressed_text = "short"
+    results_long = metric.evaluate(original_text=long_original_text, compressed_text=short_compressed_text)
+    assert openai_model_name not in results_long["embedding_similarity"]
+    mock_embed_text_oai.assert_not_called()
+    assert any(record.levelname == "WARNING" and f"Input exceeds model_max_length for {openai_model_name}; skipping" in record.message for record in caplog.records)
+
+
+def test_hf_tokenizer_max_length_and_skipping(monkeypatch, caplog):
+    hf_model_name = "sentence-transformers/all-MiniLM-L6-v2"
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=[hf_model_name])
+    original_text = "original text for hf"; compressed_text = "compressed text for hf"
+    expected_orig_tokens_normal = 100; expected_comp_tokens_normal = 50;
+    expected_comp_tokens_final_normal = 50
+
+    mock_ep_embed = MagicMock(return_value=[[0.5, 0.6], [0.7, 0.8]])
+    monkeypatch.setattr(ep, "embed_text", mock_ep_embed)
+    mock_tu_token_count = MagicMock()
+    monkeypatch.setattr('compact_memory.validation.embedding_metrics.token_utils.token_count', mock_tu_token_count)
+    mock_autotokenizer_class = MagicMock(spec=transformers.AutoTokenizer)
+    mock_hf_tokenizer_instance = MagicMock()
+    mock_autotokenizer_class.from_pretrained.return_value = mock_hf_tokenizer_instance
+    monkeypatch.setattr(transformers, "AutoTokenizer", mock_autotokenizer_class)
+
+    # Scenario 1: Within Limits
+    mock_hf_tokenizer_instance.model_max_length = 512
+    mock_tu_token_count.side_effect = [expected_orig_tokens_normal, expected_comp_tokens_normal, expected_comp_tokens_final_normal]
+    results_scen1 = metric.evaluate(original_text=original_text, compressed_text=compressed_text)
+    assert hf_model_name in results_scen1["embedding_similarity"]
+    model_results_scen1 = results_scen1["embedding_similarity"][hf_model_name]
+    assert np.isclose(model_results_scen1["similarity"], np.dot([0.5, 0.6], [0.7, 0.8]))
+    assert model_results_scen1["token_count"] == expected_comp_tokens_final_normal
+    mock_ep_embed.assert_called_once(); mock_autotokenizer_class.from_pretrained.assert_called_with(hf_model_name)
+
+    # Scenario 2: Exceeds Limits (original_text too long)
+    mock_ep_embed.reset_mock(); mock_autotokenizer_class.from_pretrained.reset_mock(); caplog.clear()
+    mock_hf_tokenizer_instance.model_max_length = 512
+    mock_tu_token_count.side_effect = [600, expected_comp_tokens_normal]
+    results_scen2 = metric.evaluate(original_text=original_text, compressed_text=compressed_text)
+    assert hf_model_name not in results_scen2["embedding_similarity"]
+    mock_ep_embed.assert_not_called()
+    assert any(record.levelname == "WARNING" and f"Input exceeds model_max_length for {hf_model_name}; skipping" in record.message for record in caplog.records)
+
+    # Scenario 2b: Exceeds Limits (compressed_text too long)
+    mock_ep_embed.reset_mock(); mock_autotokenizer_class.from_pretrained.reset_mock(); caplog.clear()
+    mock_hf_tokenizer_instance.model_max_length = 512
+    mock_tu_token_count.side_effect = [expected_orig_tokens_normal, 600]
+    results_scen2b = metric.evaluate(original_text=original_text, compressed_text=compressed_text)
+    assert hf_model_name not in results_scen2b["embedding_similarity"]
+    mock_ep_embed.assert_not_called()
+    assert any(record.levelname == "WARNING" and f"Input exceeds model_max_length for {hf_model_name}; skipping" in record.message for record in caplog.records)
+
+    # Scenario 3: Invalid or Missing model_max_length
+    invalid_max_lens = {"is_none": None, "is_zero": 0, "is_negative": -100, "is_str": "not-an-int", "attr_missing": 'MAGIC_ATTR_MISSING_SENTINEL'}
+    for case_name, max_len_val in invalid_max_lens.items():
+        mock_ep_embed.reset_mock(); mock_autotokenizer_class.from_pretrained.reset_mock(); caplog.clear(); mock_tu_token_count.reset_mock()
+        current_mock_hf_tokenizer_instance = MagicMock()
+        if max_len_val == 'MAGIC_ATTR_MISSING_SENTINEL':
+            if hasattr(current_mock_hf_tokenizer_instance, 'model_max_length'): del current_mock_hf_tokenizer_instance.model_max_length
+        else: current_mock_hf_tokenizer_instance.model_max_length = max_len_val
+        mock_autotokenizer_class.from_pretrained.return_value = current_mock_hf_tokenizer_instance
+        mock_tu_token_count.side_effect = [expected_comp_tokens_final_normal]
+        results_scen3 = metric.evaluate(original_text=original_text, compressed_text=compressed_text)
+        assert hf_model_name in results_scen3["embedding_similarity"], f"Failed for case: {case_name}"
+        model_results_scen3 = results_scen3["embedding_similarity"][hf_model_name]
+        assert np.isclose(model_results_scen3["similarity"], np.dot([0.5, 0.6], [0.7, 0.8])), f"Failed for case: {case_name}"
+        assert model_results_scen3["token_count"] == expected_comp_tokens_final_normal, f"Failed for case: {case_name}"
+        mock_ep_embed.assert_called_once()
+        assert not any(record.levelname == "WARNING" and "Input exceeds model_max_length" in record.message for record in caplog.records)
+
+
+def test_tokenizer_load_failure(monkeypatch, caplog):
+    bad_hf_model_name = "completely-invalid/non-existent-hf-model"
+    bad_openai_model_name = "openai/non-existent-openai-model"
+    bad_openai_base_name = "non-existent-openai-model"
+    valid_hf_model_name = "valid-hf-model/dummy-hf"
+
+    model_names = [bad_hf_model_name, bad_openai_model_name, valid_hf_model_name]
+    metric = MultiModelEmbeddingSimilarityMetric(model_names=model_names)
+    original_text = "text a"; compressed_text = "text b"
+
+    mock_general_embed_text = MagicMock(return_value=[[0.1,0.1],[0.2,0.2]])
+    monkeypatch.setattr(ep, "embed_text", mock_general_embed_text)
+
+    mock_general_tu_token_count = MagicMock(side_effect=[10, 5, 5])
+    monkeypatch.setattr('compact_memory.validation.embedding_metrics.token_utils.token_count', mock_general_tu_token_count)
+
+    mock_valid_hf_tokenizer_instance = MagicMock()
+    mock_valid_hf_tokenizer_instance.model_max_length = 128
+
+    def hf_autotokenizer_side_effect(model_name, **kwargs):
+        if model_name == bad_hf_model_name:
+            raise OSError("HF tokenizer load error for bad_hf_model")
+        elif model_name == valid_hf_model_name:
+            return mock_valid_hf_tokenizer_instance
+        pytest.fail(f"Unexpected call to AutoTokenizer.from_pretrained with {model_name}")
+
+    mock_hf_autotokenizer_class = MagicMock(spec=transformers.AutoTokenizer)
+    mock_hf_autotokenizer_class.from_pretrained.side_effect = hf_autotokenizer_side_effect
+    monkeypatch.setattr(transformers, "AutoTokenizer", mock_hf_autotokenizer_class)
+
+    def mock_tiktoken_efm_for_failure(model_name_arg):
+        if model_name_arg == bad_openai_base_name:
+            raise ValueError("Primary tiktoken error for bad_openai_base_name")
+        return MagicMock(spec=tiktoken.Encoding)
+
+    def mock_tiktoken_ge_for_failure(encoding_name_arg):
+        if encoding_name_arg == "gpt2":
+            raise ValueError("Fallback gpt2 error for bad_openai_base_name")
+        return MagicMock(spec=tiktoken.Encoding)
+
+    with patch('tiktoken.encoding_for_model', side_effect=mock_tiktoken_efm_for_failure), \
+         patch('tiktoken.get_encoding', side_effect=mock_tiktoken_ge_for_failure):
+
+        results = metric.evaluate(original_text=original_text, compressed_text=compressed_text)
+
+    assert bad_hf_model_name not in results["embedding_similarity"]
+    assert bad_openai_model_name not in results["embedding_similarity"]
+    assert valid_hf_model_name in results["embedding_similarity"]
+
+    valid_model_results = results["embedding_similarity"][valid_hf_model_name]
+    assert valid_model_results["token_count"] == 5
+    assert np.isclose(valid_model_results["similarity"], np.dot([0.1,0.1],[0.2,0.2]))
+
+    log_text = caplog.text
+    # Corrected log message check (without "OSError: ")
+    assert f"Failed loading tokenizer for {bad_hf_model_name}: HF tokenizer load error for bad_hf_model" in log_text
+    assert f"Failed loading tokenizer for {bad_openai_model_name}: Fallback gpt2 error for bad_openai_base_name" in log_text
+
+    mock_hf_autotokenizer_class.from_pretrained.assert_any_call(valid_hf_model_name)
+    was_embed_text_called_for_valid_model = False
+    for call in mock_general_embed_text.call_args_list:
+        _, kwargs = call
+        if kwargs.get("model_name") == valid_hf_model_name:
+            was_embed_text_called_for_valid_model = True
+            break
+    assert was_embed_text_called_for_valid_model
+    assert mock_general_tu_token_count.call_count == 3


### PR DESCRIPTION
This commit introduces enhancements to the embedding similarity evaluation to support multiple encoder models, providing a more robust and unbiased measure of semantic preservation in compressed text.

Key changes:

1.  **Refined `MultiModelEmbeddingSimilarityMetric`**:
    *   Improved determination of `model_max_length` for OpenAI models using a predefined dictionary and fallback logic (`_get_tokenizer`).
    *   Ensured model-specific tokenizers (`tiktoken` for OpenAI, `AutoTokenizer` for HuggingFace) are used for token counting and length checks.
    *   The metric returns a nested dictionary: `{"embedding_similarity": {"<ModelName>": {"token_count": X, "similarity": Y}}}`.
    *   Models are skipped gracefully if text length exceeds their capacity or if tokenizer/embedding fails, with warnings logged.
    *   Uses a default list of diverse SentenceTransformer models if none are specified.

2.  **Enhanced Testing**:
    *   Added comprehensive tests for `MultiModelEmbeddingSimilarityMetric`, covering OpenAI and HuggingFace model scenarios, including tokenizer loading, `model_max_length` handling, token counting, model skipping logic, and error handling for tokenizer load failures.
    *   Improved existing tests for clarity and robustness.

3.  **CLI Integration**:
    *   The `evaluate-compression` and `evaluate-engines` CLI commands now fully support `MultiModelEmbeddingSimilarityMetric`.
    *   The `--embedding-model` flag allows you to specify multiple model names (repeatedly or as a JSON list) for these commands.
    *   CLI help strings for these commands have been updated to reflect new functionality, output formats, and performance considerations.

4.  **Documentation Updates**:
    *   Updated the class docstring for `MultiModelEmbeddingSimilarityMetric` to detail its programmatic usage, parameters, and return structure.
    *   Revised the "Multi-model Similarity" section in `docs/DEVELOPING_VALIDATION_METRICS.md` to accurately describe `MultiModelEmbeddingSimilarityMetric`.

5.  **Deprecation**:
    *   The older `MultiEmbeddingSimilarityMetric` (ID `embedding_similarity_multi`) is now deprecated in favor of `MultiModelEmbeddingSimilarityMetric`. A `DeprecationWarning` is issued upon its instantiation, and its tests are updated accordingly.

These changes fulfill the requirements for robust multi-encoder semantic similarity evaluation, enhancing the framework's ability to assess compression quality from multiple perspectives.