### PR TITLE
feat: Enable PipelineEngine usage from CLI

### DIFF
--- a/docs/COMPRESSION_ENGINES.md
+++ b/docs/COMPRESSION_ENGINES.md
@@ -70,6 +70,34 @@ Compression is not necessarily about achieving the highest possible data compres
 *   **Cons:** Complex to implement. Knowledge extraction can be error-prone.
 *   **Use Cases:** Building comprehensive knowledge bases, semantic search, advanced reasoning.
 
+### g. Pipeline Engine (`pipeline`)
+
+The `PipelineEngine` is a meta-engine that allows you to chain multiple compression engines together. Each engine in the pipeline processes the output of the previous one. This enables the creation of sophisticated, multi-stage compression strategies by combining the strengths of different individual engines.
+
+**CLI Usage:**
+
+To use the `PipelineEngine` from the CLI, specify `--engine pipeline` and provide the pipeline configuration as a JSON string to the `--pipeline-config` option.
+
+**Example:**
+
+This example first prunes stopwords from the input text and then truncates the result to a maximum of 50 tokens.
+
+```bash
+compact-memory compress --engine pipeline \
+  --pipeline-config '{"engines": [
+    {"engine_name": "StopwordPrunerEngine", "engine_params": {"lang": "english"}},
+    {"engine_name": "SimpleTruncateEngine", "engine_params": {"max_tokens": 50}}
+  ]}' \
+  --file input.txt --budget 50 --output output.txt
+```
+
+The JSON structure for `--pipeline-config` is:
+`{"engines": [{"engine_name": "engine_id", "engine_params": {...}}, ...]}`
+
+Each `engine_id` must be a registered compression engine, and `engine_params` are the parameters specific to that engine.
+
+Refer to the [CLI Reference](cli_reference.md#using-the-pipelineengine---engine-pipeline) for more details on configuration and further examples.
+
 ## 3. Key Considerations for Choosing/Designing a Compression Engine
 
 *   **Information Fidelity:** How much of the original, important information is preserved?

--- a/docs/ENGINE_DEVELOPMENT.md
+++ b/docs/ENGINE_DEVELOPMENT.md
@@ -216,6 +216,7 @@ Rigorous testing is crucial when developing new engines.
 1.  **Unit Tests:**
     *   Write standard Python unit tests for your engine's core logic. Test edge cases, different input types, and budget handling.
     *   Mock external dependencies like LLM calls if necessary.
+    *   **Testing Engine Interactions:** You can also test the interaction of multiple engines in a sequence using the built-in `PipelineEngine` directly from the CLI. This is done by specifying `--engine pipeline` and providing a JSON configuration via the `--pipeline-config` option to the `compact-memory compress` command. See the [CLI Reference](cli_reference.md#using-the-pipelineengine---engine-pipeline) for usage details. This can be helpful to see how your engine behaves when it receives input from another engine or when its output is passed to another.
 
 
 ## Registering Your Engine

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -64,6 +64,13 @@ When you need to compress all text files within a directory (and optionally its 
     ```
     *(Expected output: `project_docs/compressed_output.txt`)*
 
+### Advanced Usage: Chaining Engines with `PipelineEngine`
+
+For more complex compression scenarios, you can chain multiple compression engines together using the `PipelineEngine`. This allows the output of one engine to become the input for the next, enabling multi-stage processing. This is configured via the `--pipeline-config` option when using `--engine pipeline` with the `compact-memory compress` command.
+
+This powerful feature lets you combine different strategies, for example, first pruning irrelevant content with one engine and then summarizing the result with another.
+
+See the [Compression Engines documentation](COMPRESSION_ENGINES.md#g-pipeline-engine-pipeline) or the [CLI Reference](cli_reference.md#using-the-pipelineengine---engine-pipeline) for detailed examples and configuration instructions.
 
 ### Using Compressed Output in an LLM Prompt
 

--- a/examples/cli_pipeline_examples.md
+++ b/examples/cli_pipeline_examples.md
@@ -1,0 +1,55 @@
+# Command-Line Examples for PipelineEngine
+
+This document provides examples of how to use the `PipelineEngine` with the `compact-memory compress` command-line interface. The `PipelineEngine` allows you to chain multiple compression engines together, where the output of one engine becomes the input for the next.
+
+## Example 1: Simple Pipeline (No Compression -> First/Last Selection)
+
+**Description:**
+This example demonstrates a basic pipeline. The first stage uses `NoCompressionEngine`, which, if the budget is sufficient for the input text, passes the text through unaltered. The second stage uses `FirstLastEngine` to select a specific number of units (e.g., words or sentences, depending on its internal tokenizer and logic) from the beginning and end of the text.
+
+**Command:**
+```bash
+compact-memory compress --engine pipeline \
+  --pipeline-config '{
+    "engines": [
+      {"engine_name": "NoCompressionEngine", "engine_params": {}},
+      {"engine_name": "FirstLastEngine", "engine_params": {"first_n": 10, "last_n": 5}}
+    ]
+  }' \
+  --text "This is a very long example sentence that we want to process using a pipeline. It has many words, and we will see how the FirstLastEngine truncates it after the NoCompressionEngine does nothing effectively. The middle part should be gone." \
+  --budget 20
+```
+
+**Expected Outcome:**
+The `NoCompressionEngine` will pass the full text to the `FirstLastEngine` (assuming the initial text within the overall `--budget` allows, though `NoCompressionEngine` itself doesn't strictly enforce a budget in the same way other engines might; it's more of a pass-through or minimal change engine). The `FirstLastEngine` will then process this text. If its internal logic splits by words, the output would roughly be the first 10 words and the last 5 words of the input sentence, concatenated. The actual output depends on the `FirstLastEngine`'s tokenization and unit handling. The `--budget 20` applies to the final output of the pipeline.
+
+## Example 2: Pipeline with Engine-Specific Parameters (Stopword Pruning -> First/Last Selection)
+
+**Description:**
+This pipeline first processes the text with `StopwordPrunerEngine` to remove common words (stopwords) based on the specified language. The output of this pruning step (text with stopwords removed) is then passed to `FirstLastEngine`. `FirstLastEngine` then selects the first and last few units from the pruned text. The `llm_token_budget` within `FirstLastEngine`'s `engine_params` is an example of a parameter that might be specific to how that engine further constrains its own output, separate from the global `--budget` which the pipeline aims for as a whole.
+
+**Command:**
+```bash
+compact-memory compress --engine pipeline \
+  --pipeline-config '{
+    "engines": [
+      {"engine_name": "StopwordPrunerEngine", "engine_params": {"lang": "english"}},
+      {"engine_name": "FirstLastEngine", "engine_params": {"first_n": 3, "last_n": 3, "llm_token_budget": 30}}
+    ]
+  }' \
+  --text "This is an example sentence with many common words like the, is, an, and with. We will try to prune stopwords and then take the first and last few important words that remain." \
+  --budget 30
+```
+
+**Expected Outcome:**
+First, the `StopwordPrunerEngine` removes common English stopwords (e.g., "this", "is", "an", "with", "the"). The resulting text, now shorter and denser with keywords, is then processed by `FirstLastEngine`. This engine will take the first 3 and last 3 units (words/sentences) from the stopword-pruned text. The final output will be a concise version of the sentence, focusing on the less common words from the beginning and end of the pruned version, and aiming to be within the global `--budget` of 30 tokens.
+
+## Note on Engine Availability
+
+The availability of specific compression engines mentioned in these examples (e.g., `NoCompressionEngine`, `FirstLastEngine`, `StopwordPrunerEngine`) depends on your Compact Memory installation and any additionally installed engine plugins. These are often part of the core or example engines provided with the framework.
+
+## Further Information
+
+For more detailed information on using the `compact-memory compress` command and configuring the `PipelineEngine`, please refer to the main documentation, particularly:
+*   [CLI Reference](../docs/cli_reference.md#using-the-pipelineengine---engine-pipeline)
+*   [Compression Engines Overview](../docs/COMPRESSION_ENGINES.md#g-pipeline-engine-pipeline)


### PR DESCRIPTION
This change introduces the ability to use the `PipelineEngine` directly from the `compact-memory compress` command-line interface. You can now specify a sequence of compression engines to be applied to an input by using `--engine pipeline` and providing a JSON configuration string via the new `--pipeline-config` option.

The JSON configuration should follow this structure: `'{"engines": [{"engine_name": "name", "engine_params": {...}}, ...]}'`

Key changes include:
- Added `--pipeline-config` option to `compress_commands.py`.
- Modified CLI logic to parse the JSON config and instantiate `PipelineEngine` with the specified sub-engines and parameters.
- Included input validation and error handling for the new option and JSON parsing.

Documentation has been updated to reflect this new functionality:
- `docs/cli_reference.md`: Detailed explanation and examples for `--pipeline-config`.
- `docs/COMPRESSION_ENGINES.md`: Added `PipelineEngine` with its CLI usage.
- `docs/ENGINE_DEVELOPMENT.md`: Mentioned CLI pipeline usage for testing.
- `docs/USAGE.md`: Briefly noted the new capability.

New CLI examples have been added to `examples/cli_pipeline_examples.md`.

Comprehensive unit tests have been added to `tests/test_cli_compress.py` to cover various valid and invalid scenarios for `PipelineEngine` CLI usage.