### PR TITLE
Fix indefinite articles in docs

### DIFF
--- a/docs/EXPLAINABLE_COMPRESSION.md
+++ b/docs/EXPLAINABLE_COMPRESSION.md
@@ -1,7 +1,7 @@
 # Explainable Compression and Trace Visualization
 
 Compact Memory aims to make compression engines transparent and debuggable. A
-`CompressionTrace` records the internal decisions of a engine so that
+`CompressionTrace` records the internal decisions of an engine so that
 experiments can be analysed after the fact. The following guidelines describe how
 to produce informative traces and inspect them.
 

--- a/docs/SHARING_ENGINES.md
+++ b/docs/SHARING_ENGINES.md
@@ -1,6 +1,6 @@
 # Sharing and Discovering Compression Engines
 
-Compact Memory's plugin system enables developers to create, package, and share their custom compression engines, and for users to easily discover and integrate them. This document outlines the plugin architecture, how to package a engine, and how to use shared engines.
+Compact Memory's plugin system enables developers to create, package, and share their custom compression engines, and for users to easily discover and integrate them. This document outlines the plugin architecture, how to package an engine, and how to use shared engines.
 
 ## Plugin Architecture
 
@@ -139,7 +139,7 @@ This will check for required files, fields in the manifest, and basic loadabilit
     This command will show the engine ID, display name, version, and source, which helps verify if your shared engine is correctly loaded.
 
 4.  **Using Shared Engines:**
-    Once a engine is installed and discoverable, you can use it just like a built-in one by referencing its `engine_id`:
+    Once an engine is installed and discoverable, you can use it just like a built-in one by referencing its `engine_id`:
     *   **CLI:**
         ```bash
         compact-memory compress --file input.txt --engine <shared_engine_id> --budget <value>

--- a/docs/tutorials/01_integrating_into_pipelines.md
+++ b/docs/tutorials/01_integrating_into_pipelines.md
@@ -49,7 +49,7 @@ def my_llm_call(prompt: str, model_name: str = "gpt-4.1-nano") -> str:
 Compact Memory comes with built-in engines, and you might have installed others as plugins. You can list available engines using the CLI (`compact-memory dev list-engines`). For this example, we\'ll use the `first_last` engine, which simply takes the beginning and end of the text.
 
 ```python
-# Choose a engine ID
+# Choose an engine ID
 # For this example, \'first_last\' is simple. Other options could be \'truncate\',
 # or more advanced ones if available (e.g., \'prototype\' if you have an agent store).
 engine_id = "first_last"
@@ -247,4 +247,4 @@ if __name__ == "__main__":
 
 ## Conclusion
 
-This tutorial showed how to integrate Compact Memory into a Python-based LLM pipeline. By loading a engine, compressing text to a specified budget, and then using that compressed text as context for an LLM, you can effectively manage longer inputs and optimize your LLM interactions. You can adapt this workflow with different engines and integrate it into more complex applications.
+This tutorial showed how to integrate Compact Memory into a Python-based LLM pipeline. By loading an engine, compressing text to a specified budget, and then using that compressed text as context for an LLM, you can effectively manage longer inputs and optimize your LLM interactions. You can adapt this workflow with different engines and integrate it into more complex applications.

--- a/docs/tutorials/02_building_a_simple_engine.md
+++ b/docs/tutorials/02_building_a_simple_engine.md
@@ -1,5 +1,5 @@
 # Tutorial 2: Step-by-Step - Building a Simple compression engine
-This tutorial walks you through creating a basic compression engine for Compact Memory. It complements the main \`ENGINE_DEVELOPMENT.md\` guide by providing a hands-on example. We'll build a engine that keeps only the first N sentences of a text.
+This tutorial walks you through creating a basic compression engine for Compact Memory. It complements the main \`ENGINE_DEVELOPMENT.md\` guide by providing a hands-on example. We'll build an engine that keeps only the first N sentences of a text.
 ## Prerequisites
 *   `Compact Memory installed (\`pip install compact-memory\`).`
 *   `Familiarity with Python.`

--- a/docs/tutorials/03_packaging_an_engine.md
+++ b/docs/tutorials/03_packaging_an_engine.md
@@ -2,13 +2,13 @@
 This tutorial guides you through the process of packaging a custom compression engine you've developed for Compact Memory. Packaging makes your engine easily shareable, discoverable, and installable by others. We'll use the \`dev create-engine-package\` CLI command and prepare the engine for distribution.
 ## Prerequisites
 *   `Compact Memory installed (\`pip install compact-memory\`).`
-*   `You have already developed a custom compression engine (e.g., as a \`.py\` file). For this tutorial, we'll assume you have a engine in \`my_awesome_engine.py\` containing a class \`MyAwesomeEngine\` which inherits from \`BaseCompressionEngine\`.`
+*   `You have already developed a custom compression engine (e.g., as a \`.py\` file). For this tutorial, we'll assume you have an engine in \`my_awesome_engine.py\` containing a class \`MyAwesomeEngine\` which inherits from \`BaseCompressionEngine\`.`
 *   `Your \`MyAwesomeEngine\` class has a unique string attribute \`id = "awesome_strat"\`.`
 ## Goal
 By the end of this tutorial, you will have a well-structured engine package directory ready for sharing, either directly or as part of a larger Python package.
 ## Steps
 ### 1. Generate the Package Template
-Compact Memory's CLI provides a handy tool to bootstrap a engine package. Open your terminal and navigate to where you want to create your package directory.
+Compact Memory's CLI provides a handy tool to bootstrap an engine package. Open your terminal and navigate to where you want to create your package directory.
 ```bash
 compact-memory dev create-engine-package --name compact_memory_my_engine
 ```
@@ -112,4 +112,4 @@ my_strat_instance = MyEngineClass(custom_param=10)
 # ... use my_strat_instance.compress(...) ...
 ```
 ## Conclusion
-You've successfully taken a engine idea, used \`dev create-engine-package\` to structure it, configured its manifest, and prepared it for sharing. This process helps build a robust ecosystem of compression engines for Compact Memory. For more details on plugin mechanisms and distribution, always refer to \`docs/SHARING_ENGINES.md\`.
+You've successfully taken an engine idea, used \`dev create-engine-package\` to structure it, configured its manifest, and prepared it for sharing. This process helps build a robust ecosystem of compression engines for Compact Memory. For more details on plugin mechanisms and distribution, always refer to \`docs/SHARING_ENGINES.md\`.


### PR DESCRIPTION
## Summary
- correct uses of "an engine" across documentation

## Testing
- `pre-commit run --files docs/EXPLAINABLE_COMPRESSION.md docs/SHARING_ENGINES.md docs/tutorials/01_integrating_into_pipelines.md docs/tutorials/02_building_a_simple_engine.md docs/tutorials/03_packaging_an_engine.md`
- `pytest` *(fails: CliRunner.__init__() got unexpected keyword arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68464f2feaf08329837463a799c304dc