### PR TITLE
Fix tests for updated engine API

### DIFF
--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -263,7 +263,7 @@ def test_evaluate_engines_multi_model_cli(tmp_path: Path, monkeypatch):
     # Mock for CompressionRatioMetric.evaluate - to prevent it from actually calculating
     # and to control its output value.
     cr_evaluate_path = "compact_memory.validation.compression_metrics.CompressionRatioMetric.evaluate"  # Corrected path
-    mock_cr_evaluate_method = MagicMock(return_value={"compression_ratio": 0.5})
+    mock_cr_evaluate_method = MagicMock(return_value={"token_compression_ratio": 0.5})
     monkeypatch.setattr(cr_evaluate_path, mock_cr_evaluate_method)
 
     # Scenario 1 (was default run, now explicit): Multiple --embedding-model flags


### PR DESCRIPTION
## Summary
- update tests for new CompressedMemory return type
- adjust pipeline engine CLI tests for changed tokenization and error messages
- mock compression ratio metric correctly in metrics CLI tests

## Testing
- `pre-commit run --files tests/test_cli_metrics.py tests/test_cli_compress.py tests/engines/test_readagent_gist_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68465bf31c488329af620c3f138428f3