### PR TITLE
Fix duplicate registration of stopword engine

### DIFF
--- a/src/compact_memory/engines/stopword_pruner_engine.py
+++ b/src/compact_memory/engines/stopword_pruner_engine.py
@@ -169,11 +169,4 @@ class StopwordPrunerEngine(BaseCompressionEngine):
         return compressed
 
 
-register_compression_engine(
-    StopwordPrunerEngine.id,
-    StopwordPrunerEngine,
-    display_name="Stopword Pruner",
-    source="built-in",
-)
-
 __all__ = ["StopwordPrunerEngine"]


### PR DESCRIPTION
## Summary
- remove manual registration of `StopwordPrunerEngine`

## Testing
- `pre-commit run --files src/compact_memory/engines/stopword_pruner_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846cac0db908329aa817a96fff8b128