### PR TITLE
Make built‑in engines self register

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,6 @@ metrics = ["evaluate"]
 
 [project.scripts]
 compact-memory = "compact_memory.__main__:main"
-
-[project.entry-points."compact_memory.engines"]
-none = "compact_memory.engines.no_compression_engine:NoCompressionEngine"
-pipeline = "compact_memory.engines.pipeline_engine:PipelineEngine"
-first_last = "compact_memory.engines.first_last_engine:FirstLastEngine"
-stopword_pruner = "compact_memory.engines.stopword_pruner_engine:StopwordPrunerEngine"
-
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["compact_memory", "compact_memory.*"]

--- a/src/compact_memory/engines/first_last_engine.py
+++ b/src/compact_memory/engines/first_last_engine.py
@@ -94,6 +94,13 @@ class FirstLastEngine(BaseCompressionEngine):
         return compressed
 
 
-# register_compression_engine(FirstLastEngine.id, FirstLastEngine, source="contrib") # Removed, as it's now registered in engines/__init__.py
+# Register engine on import
+
+register_compression_engine(
+    FirstLastEngine.id,
+    FirstLastEngine,
+    display_name="First/Last",
+    source="built-in",
+)
 
 __all__ = ["FirstLastEngine"]

--- a/src/compact_memory/engines/no_compression_engine.py
+++ b/src/compact_memory/engines/no_compression_engine.py
@@ -8,6 +8,7 @@ from compact_memory.token_utils import truncate_text
 
 # Import directly from base to avoid triggering package-level side effects
 from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
+from .registry import register_compression_engine
 
 try:  # pragma: no cover - optional dependency
     import tiktoken
@@ -52,3 +53,12 @@ class NoCompressionEngine(BaseCompressionEngine):
 
 
 __all__ = ["NoCompressionEngine"]
+
+# Self-register on import so the engine is available without
+# explicit registration elsewhere.
+register_compression_engine(
+    NoCompressionEngine.id,
+    NoCompressionEngine,
+    display_name="No Compression",
+    source="built-in",
+)

--- a/src/compact_memory/engines/stopword_pruner_engine.py
+++ b/src/compact_memory/engines/stopword_pruner_engine.py
@@ -170,3 +170,12 @@ class StopwordPrunerEngine(BaseCompressionEngine):
 
 
 __all__ = ["StopwordPrunerEngine"]
+
+# Register engine on import to avoid hardcoded registration elsewhere
+
+register_compression_engine(
+    StopwordPrunerEngine.id,
+    StopwordPrunerEngine,
+    display_name="Stopword Pruner",
+    source="built-in",
+)


### PR DESCRIPTION
## Summary
- remove engine entrypoints
- self-register builtin engines on import

## Testing
- `pre-commit run --files pyproject.toml src/compact_memory/engines/first_last_engine.py src/compact_memory/engines/no_compression_engine.py src/compact_memory/engines/pipeline_engine.py src/compact_memory/engines/stopword_pruner_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846e515af48832993ecb24216f112ac