### PR TITLE
Enhance compression tracing

### DIFF
--- a/src/compact_memory/cli/compress_commands.py
+++ b/src/compact_memory/cli/compress_commands.py
@@ -212,13 +212,8 @@ def compress_command(  # Renamed from compress
                 fg=typer.colors.RED,
             )
             raise typer.Exit(code=1)
-        if output_trace:
-            # The message is still relevant as we are not generating a trace for the combined output yet.
-            typer.secho(
-                "Warning: --output-trace is ignored when --dir is used. A combined trace for directory mode is not yet supported.",
-                fg=typer.colors.YELLOW,
-            )
-            # output_trace = None # Disable it
+        # When outputting a directory we now allow a single trace file describing the combined compression.
+        # output_trace will be passed through to the helper that writes results.
     else:  # Single text or file input, not --memory-path, not --dir
         if output_dir:  # This validation remains correct
             typer.secho(
@@ -366,6 +361,7 @@ def compress_command(  # Renamed from compress
                 final_engine_id,
                 budget,
                 output_dir,
+                output_trace,
                 recursive,
                 pattern,
                 verbose_stats,
@@ -711,6 +707,7 @@ def _compress_directory_to_files(
     engine_id: str,
     budget: int,  # Renamed dir_path to dir_path_obj
     output_dir_obj: Optional[Path],
+    trace_file_obj: Optional[Path],
     recursive: bool,
     pattern: str,  # Renamed output_dir to output_dir_obj
     verbose_stats: bool,
@@ -795,7 +792,7 @@ def _compress_directory_to_files(
         trace_obj,  # This will be None if the engine doesn't return it, or the actual trace
         elapsed_ms,
         final_output_path,
-        None,  # trace_file is None for directory mode
+        trace_file_obj,
         verbose_stats,
         tokenizer,
         False,  # json_output is False for directory mode

--- a/src/compact_memory/engines/pipeline_engine.py
+++ b/src/compact_memory/engines/pipeline_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, asdict
 from typing import List, Union, Any, Optional
+import time
 
 # Import base classes directly to avoid package-level registration
 from .base import BaseCompressionEngine, CompressedMemory, CompressionTrace
@@ -65,6 +66,7 @@ class PipelineEngine(BaseCompressionEngine):
             previous_compression_result
         )
         accumulated_traces: List[CompressionTrace] = []
+        start = time.monotonic()
 
         # Determine the very original text for the pipeline's input summary
         original_input_text = text_or_chunks
@@ -162,6 +164,7 @@ class PipelineEngine(BaseCompressionEngine):
             output_summary={"compressed_length": len(current_compressed_memory.text)},
             final_compressed_object_preview=current_compressed_memory.text[:50],
         )
+        pipeline_trace.processing_ms = (time.monotonic() - start) * 1000
 
         # Create the final CompressedMemory object for the pipeline
         final_compressed_output = CompressedMemory(

--- a/tests/test_compression_trace.py
+++ b/tests/test_compression_trace.py
@@ -1,0 +1,11 @@
+import pytest
+from compact_memory.engines.base import CompressionTrace
+
+
+def test_add_step():
+    trace = CompressionTrace(
+        engine_name="test", strategy_params={}, input_summary={}, output_summary={}
+    )
+    trace.add_step("chunk_text", {"n": 3})
+    assert trace.steps[0]["type"] == "chunk_text"
+    assert trace.steps[0]["details"] == {"n": 3}


### PR DESCRIPTION
## Summary
- record token stats and allow step logging with `CompressionTrace.add_step`
- update built-in engines to populate detailed trace steps and timing
- allow trace output for directory compression
- add regression tests for trace details

## Testing
- `pre-commit run --files src/compact_memory/engines/base.py src/compact_memory/engines/first_last_engine.py src/compact_memory/engines/neocortex_transfer.py src/compact_memory/engines/no_compression_engine.py src/compact_memory/engines/pipeline_engine.py src/compact_memory/engines/stopword_pruner_engine.py tests/test_stopword_pruner_engine.py tests/test_compression_trace.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fbc28f60832994c212427130965c