### PR TITLE
Add semantic chunker

### DIFF
--- a/src/compact_memory/engines/base.py
+++ b/src/compact_memory/engines/base.py
@@ -196,7 +196,7 @@ class BaseCompressionEngine:
             final_compressed_object_preview=truncated[:50],
         )
         trace.add_step(
-            "truncate_content",
+            "truncate",
             {
                 "budget": budget,
                 "original_length": len(text),


### PR DESCRIPTION
## Summary
- implement `SemanticChunker` for paragraph-based chunking
- register new chunker and add tests
- ensure compression trace step matches test expectations

## Testing
- `pre-commit run --files src/compact_memory/engines/base.py src/compact_memory/chunker.py tests/test_chunker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470623f6f48329b0643e32a9558fd6