### PR TITLE
Fix engines and config defaults

### DIFF
--- a/src/compact_memory/cli/dev_commands.py
+++ b/src/compact_memory/cli/dev_commands.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import yaml
 import os
 import sys
@@ -44,7 +45,11 @@ from compact_memory.engines import (
     CompressedMemory,
     CompressionTrace,
 )
-from compact_memory.exceptions import CompactMemoryError, ConfigurationError, EngineError # Added
+from compact_memory.exceptions import (
+    CompactMemoryError,
+    ConfigurationError,
+    EngineError,
+)  # Added
 
 
 dev_app = typer.Typer(
@@ -270,12 +275,22 @@ def evaluate_compression_command(  # Renamed
         scores = metric_instance.evaluate(
             original_text=orig_text, compressed_text=comp_text
         )
-    except CompactMemoryError as exc: # Catch specific library errors from metrics
-        typer.secho(f"Error during metric evaluation with '{metric_id}': {exc}", err=True, fg=typer.colors.RED)
+    except CompactMemoryError as exc:  # Catch specific library errors from metrics
+        typer.secho(
+            f"Error during metric evaluation with '{metric_id}': {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
         raise typer.Exit(code=1)
-    except Exception as exc: # General fallback
-        typer.secho(f"An unexpected error occurred during metric evaluation with '{metric_id}': {exc}", err=True, fg=typer.colors.RED)
-        logging.exception(f"Metric evaluation failed for metric {metric_id}") # Added logging
+    except Exception as exc:  # General fallback
+        typer.secho(
+            f"An unexpected error occurred during metric evaluation with '{metric_id}': {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        logging.exception(
+            f"Metric evaluation failed for metric {metric_id}"
+        )  # Added logging
         raise typer.Exit(code=1)
 
     if json_output:
@@ -442,10 +457,16 @@ def test_llm_prompt_command(  # Renamed
             max_new_tokens=max_new_tokens,
             api_key=api_key_value,  # Pass the fetched API key
         )
-    except CompactMemoryError as exc: # Catch specific library errors from LLM providers
-        typer.secho(f"LLM generation error with model '{actual_model_name_for_provider}': {exc}", err=True, fg=typer.colors.RED)
+    except (
+        CompactMemoryError
+    ) as exc:  # Catch specific library errors from LLM providers
+        typer.secho(
+            f"LLM generation error with model '{actual_model_name_for_provider}': {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
         raise typer.Exit(code=1)
-    except Exception as exc: # General fallback
+    except Exception as exc:  # General fallback
         typer.secho(
             f"An unexpected error occurred during LLM generation with model '{actual_model_name_for_provider}': {exc}",
             err=True,
@@ -564,12 +585,22 @@ def evaluate_llm_response_command(  # Renamed
         scores = metric_instance.evaluate(
             llm_response=resp_text, reference_answer=ref_text
         )
-    except CompactMemoryError as exc: # Catch specific library errors from metrics
-        typer.secho(f"Error during metric evaluation with '{metric_id}': {exc}", err=True, fg=typer.colors.RED)
+    except CompactMemoryError as exc:  # Catch specific library errors from metrics
+        typer.secho(
+            f"Error during metric evaluation with '{metric_id}': {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
         raise typer.Exit(code=1)
-    except Exception as exc: # General fallback
-        typer.secho(f"An unexpected error occurred during metric evaluation with '{metric_id}': {exc}", err=True, fg=typer.colors.RED)
-        logging.exception(f"Metric evaluation failed for metric {metric_id}") # Added logging
+    except Exception as exc:  # General fallback
+        typer.secho(
+            f"An unexpected error occurred during metric evaluation with '{metric_id}': {exc}",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        logging.exception(
+            f"Metric evaluation failed for metric {metric_id}"
+        )  # Added logging
         raise typer.Exit(code=1)
 
     if json_output:
@@ -598,10 +629,16 @@ def download_embedding_model_command(  # Renamed
     try:
         util_download_embedding_model(model_name)
         typer.echo(f"Successfully downloaded embedding model '{model_name}'.")
-    except CompactMemoryError as e: # Catch specific library errors if download util raises them
-        typer.secho(f"Error downloading embedding model '{model_name}': {e}", fg=typer.colors.RED, err=True)
+    except (
+        CompactMemoryError
+    ) as e:  # Catch specific library errors if download util raises them
+        typer.secho(
+            f"Error downloading embedding model '{model_name}': {e}",
+            fg=typer.colors.RED,
+            err=True,
+        )
         raise typer.Exit(code=1)
-    except Exception as e: # General fallback
+    except Exception as e:  # General fallback
         typer.secho(
             f"An unexpected error occurred downloading embedding model '{model_name}': {e}",
             fg=typer.colors.RED,
@@ -626,10 +663,14 @@ def download_chat_model_command(  # Renamed
     try:
         util_download_chat_model(model_name)
         typer.echo(f"Successfully downloaded chat model '{model_name}'.")
-    except CompactMemoryError as e: # Catch specific library errors
-        typer.secho(f"Error downloading chat model '{model_name}': {e}", fg=typer.colors.RED, err=True)
+    except CompactMemoryError as e:  # Catch specific library errors
+        typer.secho(
+            f"Error downloading chat model '{model_name}': {e}",
+            fg=typer.colors.RED,
+            err=True,
+        )
         raise typer.Exit(code=1)
-    except Exception as e: # General fallback
+    except Exception as e:  # General fallback
         typer.secho(
             f"An unexpected error occurred downloading chat model '{model_name}': {e}",
             fg=typer.colors.RED,
@@ -768,11 +809,19 @@ def validate_engine_package_command(  # Renamed
         errors, warnings = validate_package_dir(package_path)
         for w_msg in warnings:
             typer.secho(f"Warning: {w_msg}", fg=typer.colors.YELLOW)
-    except CompactMemoryError as e: # If validate_package_dir raises specific errors
-        typer.secho(f"Error validating package '{package_path}': {e}", fg=typer.colors.RED, err=True)
+    except CompactMemoryError as e:  # If validate_package_dir raises specific errors
+        typer.secho(
+            f"Error validating package '{package_path}': {e}",
+            fg=typer.colors.RED,
+            err=True,
+        )
         raise typer.Exit(code=1)
-    except Exception as e: # General fallback
-        typer.secho(f"An unexpected error occurred validating package '{package_path}': {e}", fg=typer.colors.RED, err=True)
+    except Exception as e:  # General fallback
+        typer.secho(
+            f"An unexpected error occurred validating package '{package_path}': {e}",
+            fg=typer.colors.RED,
+            err=True,
+        )
         logging.exception(f"Package validation failed for {package_path}")
         raise typer.Exit(code=1)
 
@@ -879,7 +928,7 @@ def inspect_trace_command(  # Renamed
 
 @dev_app.command(
     "evaluate-engines",
-    help="Compresses text with specified engines and evaluates using a predefined set of metrics (compression_ratio and multi_model_embedding_similarity).\n\nThe --embedding-model option configures models for the multi_model_embedding_similarity metric; otherwise, its defaults are used.\nOutput is always JSON, structured as: {engine_id: {\"compression_ratio\": ..., \"embedding_similarity\": {\"model_1\": ..., \"model_2\": ...}}}.\n\nUsage Example:\n  compact-memory dev evaluate-engines --text \"example text to compress\" --engine none --embedding-model \"sentence-transformers/all-MiniLM-L6-v2\"\n\nPerformance Note: Using multiple embedding models via --embedding-model will increase the time taken for each engine's evaluation.",
+    help='Compresses text with specified engines and evaluates using a predefined set of metrics (compression_ratio and multi_model_embedding_similarity).\n\nThe --embedding-model option configures models for the multi_model_embedding_similarity metric; otherwise, its defaults are used.\nOutput is always JSON, structured as: {engine_id: {"compression_ratio": ..., "embedding_similarity": {"model_1": ..., "model_2": ...}}}.\n\nUsage Example:\n  compact-memory dev evaluate-engines --text "example text to compress" --engine none --embedding-model "sentence-transformers/all-MiniLM-L6-v2"\n\nPerformance Note: Using multiple embedding models via --embedding-model will increase the time taken for each engine\'s evaluation.',
 )
 def evaluate_engines_command(
     *,
@@ -984,33 +1033,11 @@ def evaluate_engines_command(
 
     results: dict[str, dict[str, float]] = {}
     for eid in engine_ids:
-        EngineCls = get_compression_engine(eid)
-        if eid == "pipeline":
-            engine_instance = EngineCls(PipelineConfig())
-        else:
-            engine_instance = EngineCls()
-
-        result = engine_instance.compress(text_input, budget)
-        compressed = result[0] if isinstance(result, tuple) else result
-
-        if hasattr(compressed, "text"):
-            comp_text = compressed.text
-        elif isinstance(compressed, dict):
-            comp_text = compressed.get("content", str(compressed))
-        else:
-            comp_text = str(compressed)
-
-        ratio_results = ratio_metric.evaluate(
-            original_text=text_input, compressed_text=comp_text
-        )
-        ratio = ratio_results.get("token_compression_ratio") # Or "char_compression_ratio" if preferred
-        embed_scores = embed_metric.evaluate(
-            original_text=text_input, compressed_text=comp_text
-        )["embedding_similarity"]
-
         try:
             EngineCls = get_compression_engine(eid)
-            if eid == "pipeline": # Special handling for pipeline if it needs specific config
+            if (
+                eid == "pipeline"
+            ):  # Special handling for pipeline if it needs specific config
                 # This example assumes a default/empty pipeline if not configured via params.
                 # Real usage might need a --pipeline-engine-config for this command.
                 engine_instance = EngineCls(PipelineConfig())
@@ -1040,27 +1067,46 @@ def evaluate_engines_command(
                 "embedding_similarity": embed_scores,
             }
         except ConfigurationError as e:
-            typer.secho(f"Configuration error for engine '{eid}': {e}", fg=typer.colors.YELLOW, err=True)
+            typer.secho(
+                f"Configuration error for engine '{eid}': {e}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
             results[eid] = {"error": str(e)}
         except EngineError as e:
-            typer.secho(f"Error during compression with engine '{eid}': {e}", fg=typer.colors.YELLOW, err=True)
+            typer.secho(
+                f"Error during compression with engine '{eid}': {e}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
             results[eid] = {"error": str(e)}
         except CompactMemoryError as e:
-            typer.secho(f"An error occurred with engine '{eid}': {e}", fg=typer.colors.YELLOW, err=True)
+            typer.secho(
+                f"An error occurred with engine '{eid}': {e}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
             results[eid] = {"error": str(e)}
         except Exception as e:
-            typer.secho(f"An unexpected error occurred with engine '{eid}': {e}", fg=typer.colors.YELLOW, err=True)
+            typer.secho(
+                f"An unexpected error occurred with engine '{eid}': {e}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
             logging.exception(f"Evaluation failed for engine {eid}")
             results[eid] = {"error": f"Unexpected: {str(e)}"}
 
-
-    json_output_str = json.dumps(results, indent=2) # Renamed variable
+    json_output_str = json.dumps(results, indent=2)  # Renamed variable
     if output:
         try:
             output.write_text(json_output_str)
             typer.echo(f"Results saved to {output}")
         except Exception as e:
-            typer.secho(f"Error writing results to file '{output}': {e}", fg=typer.colors.RED, err=True)
+            typer.secho(
+                f"Error writing results to file '{output}': {e}",
+                fg=typer.colors.RED,
+                err=True,
+            )
             # Still print to console if file write fails
             typer.echo(json_output_str)
             raise typer.Exit(code=1)

--- a/src/compact_memory/engine_config.py
+++ b/src/compact_memory/engine_config.py
@@ -1,6 +1,7 @@
 from typing import Optional, Any, Dict
 from pydantic import BaseModel, Field
 
+
 class EngineConfig(BaseModel):
     """
     Configuration for a BaseCompressionEngine, including chunker, vector store,
@@ -8,13 +9,32 @@ class EngineConfig(BaseModel):
     In Pydantic V2, extra fields are automatically
     stored in `model_extra` when `Config.extra = 'allow'`.
     """
-    chunker_id: str = Field(default="fixed_size", description="Identifier for the chunker to use.")
-    vector_store: str = Field(default="in_memory", description="Identifier for the vector store to use.") # Changed default
-    embedding_dim: Optional[int] = Field(default=None, description="Dimension of embeddings. If None, it might be inferred.")
-    vector_store_path: Optional[str] = Field(default=None, description="Path for persistent vector stores.")
-    embedding_fn_path: Optional[str] = Field(default=None, description="Path to the embedding function, e.g., 'module.submodule.function_name'.")
-    preprocess_fn_path: Optional[str] = Field(default=None, description="Path to the preprocessing function, e.g., 'module.submodule.function_name'.")
-    enable_trace: bool = Field(default=True, description="Whether to generate a compression trace during the compress operation.")
+
+    chunker_id: str = Field(
+        default="fixed_size", description="Identifier for the chunker to use."
+    )
+    vector_store: str = Field(
+        default="faiss_memory", description="Identifier for the vector store to use."
+    )
+    embedding_dim: Optional[int] = Field(
+        default=None,
+        description="Dimension of embeddings. If None, it might be inferred.",
+    )
+    vector_store_path: Optional[str] = Field(
+        default=None, description="Path for persistent vector stores."
+    )
+    embedding_fn_path: Optional[str] = Field(
+        default=None,
+        description="Path to the embedding function, e.g., 'module.submodule.function_name'.",
+    )
+    preprocess_fn_path: Optional[str] = Field(
+        default=None,
+        description="Path to the preprocessing function, e.g., 'module.submodule.function_name'.",
+    )
+    enable_trace: bool = Field(
+        default=True,
+        description="Whether to generate a compression trace during the compress operation.",
+    )
 
     # No explicit model_extra field or validator needed for Pydantic V2.
     # Extras are handled by `model.model_extra` property if `Config.extra = 'allow'`.
@@ -25,4 +45,8 @@ class EngineConfig(BaseModel):
     # For now, sticking to class Config as per existing structure, will address warning later if needed.
     class Config:
         validate_assignment = True
-        extra = 'allow'
+        extra = "allow"
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve ``key`` similar to ``dict.get``."""
+        return self.model_extra.get(key, getattr(self, key, default))

--- a/src/compact_memory/engines/no_compression_engine.py
+++ b/src/compact_memory/engines/no_compression_engine.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 """Simple no-op compression engine."""
 
 import time
-import logging # Moved import logging to top
-from typing import Any, List, Optional, Union # Added Union for text_or_chunks
+import logging  # Moved import logging to top
+from typing import Any, List, Optional, Union  # Added Union for text_or_chunks
 
 from compact_memory.token_utils import truncate_text
 
@@ -15,6 +15,7 @@ from .registry import register_compression_engine
 
 try:  # pragma: no cover - optional dependency
     import tiktoken
+
     _DEFAULT_TOKENIZER: Optional[tiktoken.Encoding] = tiktoken.get_encoding("gpt2")
 except Exception:  # pragma: no cover - optional dependency
     _DEFAULT_TOKENIZER = None
@@ -27,7 +28,7 @@ class NoCompressionEngine(BaseCompressionEngine):
 
     def compress(
         self,
-        text_or_chunks: Union[str, List[str]], # Used Union explicitly
+        text_or_chunks: Union[str, List[str]],  # Used Union explicitly
         budget: int | None,
         *,
         tokenizer: Any = None,
@@ -45,8 +46,12 @@ class NoCompressionEngine(BaseCompressionEngine):
         logging.debug(f"NoCompressionEngine: Processing text, budget: {budget}")
         # Ensure tokenizer is not None for truncate_text if budget is not None
         active_tokenizer: Any = tokenizer or _DEFAULT_TOKENIZER
-        if active_tokenizer is None and budget is not None: # If no tokenizer and budget is set, truncation might behave unexpectedly or fail
-             active_tokenizer = lambda t, **_: t.split() # Fallback to simple split for truncate_text's tokenizer requirement
+        if (
+            active_tokenizer is None and budget is not None
+        ):  # If no tokenizer and budget is set, truncation might behave unexpectedly or fail
+            active_tokenizer = (
+                lambda t, **_: t.split()
+            )  # Fallback to simple split for truncate_text's tokenizer requirement
 
         start_time = time.monotonic()
 
@@ -66,21 +71,21 @@ class NoCompressionEngine(BaseCompressionEngine):
                 text=final_text,
                 trace=None,
                 engine_id=self.id,
-                engine_config=self.config.model_dump(mode='json')
+                engine_config=self.config.model_dump(mode="json"),
             )
 
         # Proceed with trace generation
         trace = CompressionTrace(
             engine_name=self.id,
-            strategy_params={"budget": budget}, # Use renamed budget
-            input_summary={"input_length": len(input_text_content)}, # Original length
-            output_summary={"output_length": len(final_text)}, # Final length
+            strategy_params={"llm_token_budget": budget},
+            input_summary={"input_length": len(input_text_content)},  # Original length
+            output_summary={"output_length": len(final_text)},  # Final length
             final_compressed_object_preview=final_text[:50],
         )
         trace.add_step(
             "truncate_content" if budget is not None else "no_op",
             {
-                "budget": budget, # Use renamed budget
+                "llm_token_budget": budget,
                 "result_length": len(final_text),
             },
         )
@@ -90,7 +95,7 @@ class NoCompressionEngine(BaseCompressionEngine):
             text=final_text,
             trace=trace,
             engine_id=self.id,
-            engine_config=self.config.model_dump(mode='json')
+            engine_config=self.config.model_dump(mode="json"),
         )
 
 


### PR DESCRIPTION
## Summary
- ensure BaseCompressionEngine id reflects truncation logic
- default vector store is `faiss_memory` but BaseCompressionEngine overrides to `in_memory` when unspecified
- add `EngineConfig.get` helper
- handle various PipelineEngine inputs and include budget/engines in results
- align CLI evaluate-engines command

## Testing
- `pre-commit run --files src/compact_memory/cli/dev_commands.py src/compact_memory/engine_config.py src/compact_memory/engines/base.py src/compact_memory/engines/first_last_engine.py src/compact_memory/engines/no_compression_engine.py src/compact_memory/engines/pipeline_engine.py src/compact_memory/vector_store.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475d25374c83298a5a802cd943f9a6