### PR TITLE
Serialize custom callbacks for engines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyyaml",
     "typer>=0.16.0",
     "portalocker",
+    "cloudpickle",
     "rich>=13.6",
     "platformdirs",
     "nltk",


### PR DESCRIPTION
## Summary
- support serializing custom embedding and preprocess functions with cloudpickle
- save/load callback pickles alongside engine data
- add cloudpickle dependency

## Testing
- `pre-commit run --files pyproject.toml src/compact_memory/engines/base.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476628869c832992dc3300337827fd